### PR TITLE
refactor: make AdapterResolver.resolve() a static method (#20)

### DIFF
--- a/src/cli/commands/pipeline.ts
+++ b/src/cli/commands/pipeline.ts
@@ -48,7 +48,7 @@ export function registerPipelineCommands(program: Command): void {
       // Initialize services
       const stageRegistry = new StageRegistry(stagesDir);
       const knowledgeStore = new KnowledgeStore(kataDirPath(ctx.kataDir, 'knowledge'));
-      const adapterResolver = new AdapterResolver();
+      const adapterResolver = AdapterResolver;
       const resultCapturer = new ResultCapturer(ctx.kataDir);
       const tokenTracker = new TokenTracker(kataDirPath(ctx.kataDir, 'tracking'));
 

--- a/src/domain/ports/adapter-resolver.ts
+++ b/src/domain/ports/adapter-resolver.ts
@@ -4,6 +4,10 @@ import type { IExecutionAdapter } from './execution-adapter.js';
 /**
  * Port interface for resolving execution adapters from project configuration.
  * Used by PipelineRunner without depending on the concrete AdapterResolver class.
+ *
+ * Satisfied by `AdapterResolver` (the class constructor, not an instance) since
+ * `AdapterResolver.resolve` is a static method and static methods are properties
+ * of the class value itself.
  */
 export interface IAdapterResolver {
   resolve(config?: KataConfig): IExecutionAdapter;

--- a/src/infrastructure/execution/adapter-resolver.test.ts
+++ b/src/infrastructure/execution/adapter-resolver.test.ts
@@ -19,29 +19,27 @@ function makeConfig(adapter: string): KataConfig {
 }
 
 describe('AdapterResolver', () => {
-  const resolver = new AdapterResolver();
-
   describe('resolve', () => {
     it('resolves ManualAdapter for "manual"', () => {
-      const adapter = resolver.resolve(makeConfig('manual'));
+      const adapter = AdapterResolver.resolve(makeConfig('manual'));
       expect(adapter).toBeInstanceOf(ManualAdapter);
       expect(adapter.name).toBe('manual');
     });
 
     it('resolves ClaudeCliAdapter for "claude-cli"', () => {
-      const adapter = resolver.resolve(makeConfig('claude-cli'));
+      const adapter = AdapterResolver.resolve(makeConfig('claude-cli'));
       expect(adapter).toBeInstanceOf(ClaudeCliAdapter);
       expect(adapter.name).toBe('claude-cli');
     });
 
     it('resolves ComposioAdapter for "composio"', () => {
-      const adapter = resolver.resolve(makeConfig('composio'));
+      const adapter = AdapterResolver.resolve(makeConfig('composio'));
       expect(adapter).toBeInstanceOf(ComposioAdapter);
       expect(adapter.name).toBe('composio');
     });
 
     it('defaults to ManualAdapter when config is undefined', () => {
-      const adapter = resolver.resolve(undefined);
+      const adapter = AdapterResolver.resolve(undefined);
       expect(adapter).toBeInstanceOf(ManualAdapter);
     });
 
@@ -55,18 +53,17 @@ describe('AdapterResolver', () => {
         customStagePaths: [],
         project: {},
       };
-      const adapter = resolver.resolve(config);
+      const adapter = AdapterResolver.resolve(config);
       expect(adapter).toBeInstanceOf(ManualAdapter);
     });
 
     it('throws for unknown adapter name', () => {
-      // Force an invalid adapter value to test error handling
       const config = makeConfig('nonexistent');
-      expect(() => resolver.resolve(config)).toThrow('Unknown execution adapter');
-      expect(() => resolver.resolve(config)).toThrow('nonexistent');
+      expect(() => AdapterResolver.resolve(config)).toThrow('Unknown execution adapter');
+      expect(() => AdapterResolver.resolve(config)).toThrow('nonexistent');
       // Check each built-in name is listed (order-independent)
       for (const name of ['manual', 'claude-cli', 'composio']) {
-        expect(() => resolver.resolve(config)).toThrow(name);
+        expect(() => AdapterResolver.resolve(config)).toThrow(name);
       }
     });
   });
@@ -92,7 +89,7 @@ describe('AdapterResolver', () => {
       };
       AdapterResolver.register(TEST_ADAPTER_NAME, () => fakeAdapter);
 
-      const resolved = new AdapterResolver().resolve(makeConfig(TEST_ADAPTER_NAME));
+      const resolved = AdapterResolver.resolve(makeConfig(TEST_ADAPTER_NAME));
       expect(resolved).toBe(fakeAdapter);
       expect(resolved.name).toBe(TEST_ADAPTER_NAME);
     });
@@ -102,10 +99,9 @@ describe('AdapterResolver', () => {
         name: 'manual-override',
         execute: async () => ({ success: true, artifacts: [], completedAt: new Date().toISOString() }),
       };
-      // Override 'manual' temporarily (afterEach restores it)
       AdapterResolver.register('manual', () => replacementManual);
 
-      const resolved = new AdapterResolver().resolve(makeConfig('manual'));
+      const resolved = AdapterResolver.resolve(makeConfig('manual'));
       expect(resolved).toBe(replacementManual);
     });
 
@@ -117,7 +113,7 @@ describe('AdapterResolver', () => {
       }));
 
       const config = makeConfig('nonexistent');
-      expect(() => new AdapterResolver().resolve(config)).toThrow(uniqueName);
+      expect(() => AdapterResolver.resolve(config)).toThrow(uniqueName);
     });
   });
 });

--- a/src/infrastructure/execution/adapter-resolver.ts
+++ b/src/infrastructure/execution/adapter-resolver.ts
@@ -50,7 +50,7 @@ export class AdapterResolver {
    * @returns The resolved execution adapter instance.
    * @throws Error if the adapter name is not registered.
    */
-  resolve(config?: KataConfig): IExecutionAdapter {
+  static resolve(config?: KataConfig): IExecutionAdapter {
     const adapterName = config?.execution?.adapter ?? 'manual';
     const factory = AdapterResolver.registry.get(adapterName);
 


### PR DESCRIPTION
Closes #20.

## Summary

- `AdapterResolver.resolve()` changed to `static resolve()` — matches the class's existing static-only design
- Call sites updated: `new AdapterResolver().resolve(config)` → `AdapterResolver.resolve(config)`
- `IAdapterResolver` port interface shape is unchanged (static methods satisfy it as properties of the class constructor value)
- Test file cleaned up: removed `const resolver = new AdapterResolver()` instance

## Files changed
- `src/infrastructure/execution/adapter-resolver.ts` — method made static
- `src/infrastructure/execution/adapter-resolver.test.ts` — removed instance, call via class directly
- `src/cli/commands/pipeline.ts` — `new AdapterResolver()` → `AdapterResolver`
- `src/domain/ports/adapter-resolver.ts` — JSDoc updated

## Test plan
- [x] 892 tests passing, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved adapter resolution mechanism through internal architectural refinements to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->