### PR TITLE
feat: Wave A Session 1 — run state infrastructure + agent CLI commands

### DIFF
--- a/src/cli/commands/artifact.test.ts
+++ b/src/cli/commands/artifact.test.ts
@@ -1,0 +1,208 @@
+import { join } from 'node:path';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { registerArtifactCommands } from './artifact.js';
+import { createRunTree } from '@infra/persistence/run-store.js';
+import { JsonlStore } from '@infra/persistence/jsonl-store.js';
+import { ArtifactIndexEntrySchema } from '@domain/types/run-state.js';
+import type { Run } from '@domain/types/run-state.js';
+
+function tempBase(): string {
+  return join(tmpdir(), `kata-artifact-test-${randomUUID()}`);
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    cycleId: randomUUID(),
+    betId: randomUUID(),
+    betPrompt: 'Implement auth',
+    stageSequence: ['research', 'plan'],
+    currentStage: null,
+    status: 'pending',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('registerArtifactCommands — artifact record', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerArtifactCommands(program);
+    return program;
+  }
+
+  it('records an artifact and appends to artifact-index.jsonl files', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    // Create a temp source file
+    const srcFile = join(baseDir, 'context.md');
+    writeFileSync(srcFile, '# Context\nSome content', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'technical-research',
+      '--step', 'gather-context',
+      '--file', srcFile,
+      '--summary', 'Context gathering output',
+    ]);
+
+    // Verify run-level index
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    expect(existsSync(runIndexPath)).toBe(true);
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].flavor).toBe('technical-research');
+    expect(entries[0].step).toBe('gather-context');
+    expect(entries[0].type).toBe('artifact');
+    expect(entries[0].summary).toBe('Context gathering output');
+
+    // Verify file was copied
+    expect(existsSync(entries[0].filePath)).toBe(true);
+  });
+
+  it('records a synthesis artifact at flavor root', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'synthesis.md');
+    writeFileSync(srcFile, '# Synthesis', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'technical-research',
+      '--step', 'synthesis',
+      '--file', srcFile,
+      '--summary', 'Research synthesis',
+      '--type', 'synthesis',
+    ]);
+
+    const entries = JsonlStore.readAll(
+      join(runsDir, run.id, 'artifact-index.jsonl'),
+      ArtifactIndexEntrySchema,
+    );
+    expect(entries[0].type).toBe('synthesis');
+    expect(entries[0].step).toBeNull(); // synthesis has no step
+    // Synthesis goes to synthesis.md at flavor root
+    expect(entries[0].filePath).toContain('synthesis.md');
+  });
+
+  it('outputs JSON with --json flag', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'output.md');
+    writeFileSync(srcFile, '# Output', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'tech',
+      '--step', 'step1',
+      '--file', srcFile,
+      '--summary', 'Test output',
+    ]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.type).toBe('artifact');
+    expect(parsed.flavor).toBe('tech');
+    expect(parsed.id).toBeDefined();
+  });
+
+  it('throws on invalid stage category', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'output.md');
+    writeFileSync(srcFile, '# Output', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'deploy',
+      '--flavor', 'tech',
+      '--step', 'step1',
+      '--file', srcFile,
+      '--summary', 'Test',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid stage category'));
+  });
+
+  it('throws when source file is missing', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'tech',
+      '--step', 'step1',
+      '--file', join(baseDir, 'nonexistent.md'),
+      '--summary', 'Test',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('throws on invalid --type value', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'output.md');
+    writeFileSync(srcFile, '# Output', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'tech',
+      '--step', 'step1',
+      '--file', srcFile,
+      '--summary', 'Test',
+      '--type', 'report',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --type'));
+  });
+});

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -1,0 +1,135 @@
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { basename, isAbsolute, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { Command } from 'commander';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+import { JsonlStore } from '@infra/persistence/jsonl-store.js';
+import { readRun, readFlavorState, writeFlavorState, runPaths } from '@infra/persistence/run-store.js';
+import { ArtifactIndexEntrySchema } from '@domain/types/run-state.js';
+import type { StageCategory } from '@domain/types/stage.js';
+import { StageCategorySchema } from '@domain/types/stage.js';
+
+export function registerArtifactCommands(parent: Command): void {
+  const artifact = parent
+    .command('artifact')
+    .description('Record artifacts produced during kata runs');
+
+  // kata artifact record <run-id>
+  artifact
+    .command('record <run-id>')
+    .description('Record an artifact file into a run\'s state')
+    .requiredOption('--stage <category>', 'Stage category (research|plan|build|review)')
+    .requiredOption('--flavor <name>', 'Flavor that produced the artifact')
+    .requiredOption('--step <name>', 'Step that produced the artifact (use "synthesis" for flavor-level)')
+    .requiredOption('--file <path>', 'Path to the source artifact file')
+    .requiredOption('--summary <description>', 'Short summary of the artifact content')
+    .option('--type <type>', 'Artifact type: "artifact" (default) or "synthesis"', 'artifact')
+    .action(withCommandContext(async (ctx, runId: string) => {
+      const localOpts = ctx.cmd.opts();
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+
+      // Validate stage category
+      const stageResult = StageCategorySchema.safeParse(localOpts.stage);
+      if (!stageResult.success) {
+        throw new Error(
+          `Invalid stage category "${localOpts.stage}". Must be one of: research, plan, build, review`,
+        );
+      }
+      const stage = stageResult.data as StageCategory;
+
+      // Validate artifact type
+      const artifactType = localOpts.type as string;
+      if (artifactType !== 'artifact' && artifactType !== 'synthesis') {
+        throw new Error(`Invalid --type "${artifactType}". Must be "artifact" or "synthesis".`);
+      }
+
+      // Resolve and validate source file
+      const sourcePath = isAbsolute(localOpts.file as string)
+        ? localOpts.file as string
+        : resolve(process.cwd(), localOpts.file as string);
+
+      if (!existsSync(sourcePath)) {
+        throw new Error(`Source file not found: ${sourcePath}`);
+      }
+
+      // Validate run exists
+      const run = readRun(runsDir, runId);
+      if (!run.stageSequence.includes(stage)) {
+        throw new Error(`Stage "${stage}" is not in run "${runId}"'s stage sequence.`);
+      }
+
+      const paths = runPaths(runsDir, runId);
+      const flavorDir = paths.flavorDir(stage, localOpts.flavor as string);
+      const flavorStateFile = paths.flavorStateJson(stage, localOpts.flavor as string);
+
+      // Ensure flavor directory exists (flavor may not have been explicitly initialized)
+      mkdirSync(flavorDir, { recursive: true });
+
+      const fileName = basename(sourcePath);
+      let destPath: string;
+
+      if (artifactType === 'synthesis') {
+        // Synthesis artifacts go at the flavor root as synthesis.md
+        destPath = paths.flavorSynthesis(stage, localOpts.flavor as string);
+      } else {
+        // Regular artifacts go in the artifacts/ subdirectory
+        const artifactsDir = paths.flavorArtifactsDir(stage, localOpts.flavor as string);
+        mkdirSync(artifactsDir, { recursive: true });
+        destPath = join(artifactsDir, fileName);
+      }
+
+      // Copy the file
+      copyFileSync(sourcePath, destPath);
+
+      // Build the index entry
+      const entry = {
+        id: randomUUID(),
+        stageCategory: stage,
+        flavor: localOpts.flavor as string,
+        step: artifactType === 'synthesis' ? null : (localOpts.step as string),
+        fileName,
+        filePath: destPath,
+        summary: localOpts.summary as string,
+        type: artifactType as 'artifact' | 'synthesis',
+        recordedAt: new Date().toISOString(),
+      };
+
+      // Append to flavor-level artifact-index.jsonl
+      JsonlStore.append(
+        paths.flavorArtifactIndexJsonl(stage, localOpts.flavor as string),
+        entry,
+        ArtifactIndexEntrySchema,
+      );
+
+      // Append to run-level artifact-index.jsonl
+      JsonlStore.append(paths.artifactIndexJsonl, entry, ArtifactIndexEntrySchema);
+
+      // Update flavor state.json step artifacts if applicable
+      if (artifactType === 'artifact' && existsSync(flavorStateFile)) {
+        const flavorState = readFlavorState(runsDir, runId, stage, localOpts.flavor as string);
+        const stepName = localOpts.step as string;
+        const stepIndex = flavorState.steps.findIndex((s) => s.type === stepName);
+
+        const stepRecord = stepIndex !== -1 ? flavorState.steps[stepIndex] : undefined;
+        if (stepRecord) {
+          const relativePath = destPath.replace(paths.runDir + '/', '');
+          stepRecord.artifacts.push(relativePath);
+          writeFlavorState(runsDir, runId, stage, flavorState);
+        }
+      }
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        const label = artifactType === 'synthesis' ? 'synthesis' : `artifact`;
+        console.log(`Recorded ${label}: ${fileName}`);
+        console.log(`  Stage:  ${stage}`);
+        console.log(`  Flavor: ${localOpts.flavor as string}`);
+        if (artifactType === 'artifact') {
+          console.log(`  Step:   ${localOpts.step as string}`);
+        }
+        console.log(`  Dest:   ${destPath}`);
+        console.log(`  ID:     ${entry.id}`);
+      }
+    }));
+}

--- a/src/cli/commands/decision.test.ts
+++ b/src/cli/commands/decision.test.ts
@@ -1,0 +1,344 @@
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { registerDecisionCommands } from './decision.js';
+import { createRunTree } from '@infra/persistence/run-store.js';
+import { JsonlStore } from '@infra/persistence/jsonl-store.js';
+import { DecisionEntrySchema, DecisionOutcomeEntrySchema } from '@domain/types/run-state.js';
+import type { Run } from '@domain/types/run-state.js';
+
+function tempBase(): string {
+  return join(tmpdir(), `kata-decision-test-${randomUUID()}`);
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    cycleId: randomUUID(),
+    betId: randomUUID(),
+    betPrompt: 'Implement auth',
+    stageSequence: ['research', 'plan'],
+    currentStage: null,
+    status: 'running',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('registerDecisionCommands — decision record', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerDecisionCommands(program);
+    return program;
+  }
+
+  const BASE_ARGS = (runId: string, cwd: string) => [
+    'node', 'test', '--cwd', cwd,
+    'decision', 'record', runId,
+    '--stage', 'research',
+    '--flavor', 'technical-research',
+    '--step', 'gather-context',
+    '--type', 'flavor-selection',
+    '--context', '{"betType":"auth"}',
+    '--options', '["technical-research","codebase-analysis"]',
+    '--selected', 'technical-research',
+    '--confidence', '0.87',
+    '--reasoning', 'Best match for auth bet',
+  ];
+
+  it('appends a decision entry to decisions.jsonl', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync(BASE_ARGS(run.id, baseDir));
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stageCategory).toBe('research');
+    expect(entries[0].flavor).toBe('technical-research');
+    expect(entries[0].step).toBe('gather-context');
+    expect(entries[0].decisionType).toBe('flavor-selection');
+    expect(entries[0].confidence).toBe(0.87);
+    expect(entries[0].selection).toBe('technical-research');
+    expect(entries[0].id).toBeDefined();
+    expect(entries[0].decidedAt).toBeDefined();
+  });
+
+  it('outputs recorded decision as JSON with --json flag', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    const args = ['node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--context', '{}',
+      '--options', '["a","b"]',
+      '--selected', 'a',
+      '--confidence', '0.9',
+      '--reasoning', 'Test reasoning',
+    ];
+    await program.parseAsync(args);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.decisionType).toBe('flavor-selection');
+    expect(parsed.selection).toBe('a');
+    expect(parsed.id).toBeDefined();
+  });
+
+  it('allows null flavor and step (stage-level decision)', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'capability-analysis',
+      '--context', '{"bet":"auth"}',
+      '--options', '["high","medium","low"]',
+      '--selected', 'high',
+      '--confidence', '0.75',
+      '--reasoning', 'High capability',
+    ]);
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries[0].flavor).toBeNull();
+    expect(entries[0].step).toBeNull();
+  });
+
+  it('warns but accepts unknown decision types', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'plan',
+      '--type', 'custom-judgment',
+      '--context', '{}',
+      '--options', '["a"]',
+      '--selected', 'a',
+      '--confidence', '0.5',
+      '--reasoning', 'Custom',
+    ]);
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries[0].decisionType).toBe('custom-judgment');
+    warnSpy.mockRestore();
+  });
+
+  it('errors on invalid stage', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'deploy',
+      '--type', 'flavor-selection',
+      '--context', '{}',
+      '--options', '["a"]',
+      '--selected', 'a',
+      '--confidence', '0.5',
+      '--reasoning', 'Test',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid stage category'));
+  });
+
+  it('errors on invalid confidence value', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--context', '{}',
+      '--options', '["a"]',
+      '--selected', 'a',
+      '--confidence', '1.5',
+      '--reasoning', 'Test',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('confidence'));
+  });
+
+  it('errors on invalid context JSON', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--context', 'not-json',
+      '--options', '["a"]',
+      '--selected', 'a',
+      '--confidence', '0.5',
+      '--reasoning', 'Test',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('context'));
+  });
+});
+
+describe('registerDecisionCommands — decision update', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerDecisionCommands(program);
+    return program;
+  }
+
+  async function recordDecision(runId: string): Promise<string> {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', runId,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--context', '{}',
+      '--options', '["a","b"]',
+      '--selected', 'a',
+      '--confidence', '0.8',
+      '--reasoning', 'Test reasoning',
+    ]);
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    consoleSpy.mockClear();
+    return (JSON.parse(output) as { id: string }).id;
+  }
+
+  it('appends outcome to decision-outcomes.jsonl', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+    const decisionId = await recordDecision(run.id);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'update', run.id, decisionId,
+      '--outcome', 'good',
+      '--notes', 'Worked perfectly',
+    ]);
+
+    const outcomesPath = join(runsDir, run.id, 'decision-outcomes.jsonl');
+    const entries = JsonlStore.readAll(outcomesPath, DecisionOutcomeEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].decisionId).toBe(decisionId);
+    expect(entries[0].outcome).toBe('good');
+    expect(entries[0].notes).toBe('Worked perfectly');
+    expect(entries[0].updatedAt).toBeDefined();
+  });
+
+  it('outputs JSON with --json flag', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+    const decisionId = await recordDecision(run.id);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'update', run.id, decisionId,
+      '--outcome', 'partial',
+    ]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.outcome).toBe('partial');
+    expect(parsed.decisionId).toBe(decisionId);
+  });
+
+  it('errors when decision ID does not exist', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'update', run.id, randomUUID(),
+      '--outcome', 'good',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('errors on invalid outcome value', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+    const decisionId = await recordDecision(run.id);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'decision', 'update', run.id, decisionId,
+      '--outcome', 'excellent',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid outcome'));
+  });
+});

--- a/src/cli/commands/decision.ts
+++ b/src/cli/commands/decision.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from 'node:crypto';
+import type { Command } from 'commander';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+import { JsonlStore } from '@infra/persistence/jsonl-store.js';
+import { readRun, readStageState, writeStageState, runPaths } from '@infra/persistence/run-store.js';
+import {
+  DecisionEntrySchema,
+  DecisionOutcomeEntrySchema,
+} from '@domain/types/run-state.js';
+import { StageCategorySchema } from '@domain/types/stage.js';
+import type { StageCategory } from '@domain/types/stage.js';
+import { DecisionTypeSchema } from '@domain/types/decision.js';
+import { logger } from '@shared/lib/logger.js';
+
+export function registerDecisionCommands(parent: Command): void {
+  const decision = parent
+    .command('decision')
+    .description('Record and update decisions made during kata runs');
+
+  // kata decision record <run-id>
+  decision
+    .command('record <run-id>')
+    .description('Append a decision to a run\'s decision log')
+    .requiredOption('--stage <category>', 'Stage category where the decision was made')
+    .option('--flavor <name>', 'Flavor context of the decision (omit for stage-level decisions)')
+    .option('--step <name>', 'Step context of the decision (omit for flavor/stage-level decisions)')
+    .requiredOption('--type <decision-type>', 'Type of decision (e.g. flavor-selection, execution-mode)')
+    .requiredOption('--context <json>', 'JSON object of contextual information at decision time')
+    .requiredOption('--options <json>', 'JSON array of available options the orchestrator considered')
+    .requiredOption('--selected <option>', 'The option that was chosen')
+    .requiredOption('--confidence <number>', 'Confidence in the selection [0-1]', parseFloat)
+    .requiredOption('--reasoning <text>', 'Orchestrator\'s reasoning for the selection')
+    .action(withCommandContext(async (ctx, runId: string) => {
+      const localOpts = ctx.cmd.opts();
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+
+      // Validate stage category
+      const stageResult = StageCategorySchema.safeParse(localOpts.stage);
+      if (!stageResult.success) {
+        throw new Error(
+          `Invalid stage category "${localOpts.stage}". Must be one of: research, plan, build, review`,
+        );
+      }
+      const stage = stageResult.data as StageCategory;
+
+      // Validate confidence
+      const confidence = localOpts.confidence as number;
+      if (Number.isNaN(confidence) || confidence < 0 || confidence > 1) {
+        throw new Error(`--confidence must be a number between 0 and 1, got: ${localOpts.confidence as string}`);
+      }
+
+      // Parse context JSON
+      let context: Record<string, unknown>;
+      try {
+        context = JSON.parse(localOpts.context as string) as Record<string, unknown>;
+        if (typeof context !== 'object' || Array.isArray(context) || context === null) {
+          throw new Error('must be a JSON object');
+        }
+      } catch (e) {
+        throw new Error(`--context must be a valid JSON object: ${e instanceof Error ? e.message : String(e)}`, { cause: e });
+      }
+
+      // Parse options JSON
+      let options: string[];
+      try {
+        const parsed: unknown = JSON.parse(localOpts.options as string);
+        if (!Array.isArray(parsed) || parsed.some((o) => typeof o !== 'string')) {
+          throw new Error('must be a JSON array of strings');
+        }
+        options = parsed as string[];
+      } catch (e) {
+        throw new Error(`--options must be a valid JSON array of strings: ${e instanceof Error ? e.message : String(e)}`, { cause: e });
+      }
+
+      if (options.length === 0) {
+        throw new Error('--options must not be empty');
+      }
+
+      // Validate decision type (warn on unknown, do not reject)
+      const decisionType = localOpts.type as string;
+      const knownTypeResult = DecisionTypeSchema.safeParse(decisionType);
+      if (!knownTypeResult.success) {
+        logger.warn(`Unknown decision type "${decisionType}". Known types: ${DecisionTypeSchema.options.join(', ')}`);
+      }
+
+      // Validate run exists
+      readRun(runsDir, runId);
+
+      const paths = runPaths(runsDir, runId);
+      const id = randomUUID();
+      const now = new Date().toISOString();
+
+      const entry = {
+        id,
+        stageCategory: stage,
+        flavor: (localOpts.flavor as string | undefined) ?? null,
+        step: (localOpts.step as string | undefined) ?? null,
+        decisionType,
+        context,
+        options,
+        selection: localOpts.selected as string,
+        reasoning: localOpts.reasoning as string,
+        confidence,
+        decidedAt: now,
+      };
+
+      // Append to run-level decisions.jsonl
+      JsonlStore.append(paths.decisionsJsonl, entry, DecisionEntrySchema);
+
+      // Update stage state decisions array
+      try {
+        const stageState = readStageState(runsDir, runId, stage);
+        stageState.decisions.push(id);
+        writeStageState(runsDir, runId, stageState);
+      } catch {
+        // Stage state file may not exist yet (e.g. run just started); that's ok
+        logger.warn(`Could not update stage state decisions for run "${runId}", stage "${stage}"`);
+      }
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        console.log(`Decision recorded: ${decisionType}`);
+        console.log(`  ID:         ${id}`);
+        console.log(`  Stage:      ${stage}`);
+        if (entry.flavor) console.log(`  Flavor:     ${entry.flavor}`);
+        if (entry.step) console.log(`  Step:       ${entry.step}`);
+        console.log(`  Selected:   ${localOpts.selected as string}`);
+        console.log(`  Confidence: ${confidence}`);
+      }
+    }));
+
+  // kata decision update <run-id> <decision-id>
+  decision
+    .command('update <run-id> <decision-id>')
+    .description('Record a post-facto outcome for a decision')
+    .requiredOption('--outcome <value>', 'Outcome quality: good | partial | poor | unknown')
+    .option('--notes <text>', 'Free-text notes about the outcome')
+    .option('--user-overrides <json>', 'JSON string of user overrides applied to the decision')
+    .action(withCommandContext(async (ctx, runId: string, decisionId: string) => {
+      const localOpts = ctx.cmd.opts();
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+
+      // Validate outcome
+      const validOutcomes = ['good', 'partial', 'poor', 'unknown'] as const;
+      if (!validOutcomes.includes(localOpts.outcome as typeof validOutcomes[number])) {
+        throw new Error(
+          `Invalid outcome "${localOpts.outcome as string}". Must be one of: ${validOutcomes.join(', ')}`,
+        );
+      }
+
+      // Validate run exists
+      readRun(runsDir, runId);
+
+      const paths = runPaths(runsDir, runId);
+
+      // Validate decision ID exists in decisions.jsonl
+      const decisions = JsonlStore.readAll(paths.decisionsJsonl, DecisionEntrySchema);
+      const decision = decisions.find((d) => d.id === decisionId);
+      if (!decision) {
+        throw new Error(
+          `Decision "${decisionId}" not found in run "${runId}". ` +
+          `Use "kata run status ${runId}" to list decision IDs.`,
+        );
+      }
+
+      const entry = {
+        decisionId,
+        outcome: localOpts.outcome as 'good' | 'partial' | 'poor' | 'unknown',
+        notes: localOpts.notes as string | undefined,
+        userOverrides: localOpts.userOverrides as string | undefined,
+        updatedAt: new Date().toISOString(),
+      };
+
+      // Append to decision-outcomes.jsonl
+      JsonlStore.append(paths.decisionOutcomesJsonl, entry, DecisionOutcomeEntrySchema);
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify(entry, null, 2));
+      } else {
+        console.log(`Decision outcome recorded.`);
+        console.log(`  Decision: ${decisionId}`);
+        console.log(`  Outcome:  ${entry.outcome}`);
+        if (entry.notes) console.log(`  Notes:    ${entry.notes}`);
+      }
+    }));
+}

--- a/src/cli/commands/run.test.ts
+++ b/src/cli/commands/run.test.ts
@@ -1,0 +1,160 @@
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { registerRunCommands } from './run.js';
+import { registerDecisionCommands } from './decision.js';
+import { createRunTree, writeStageState } from '@infra/persistence/run-store.js';
+import type { Run } from '@domain/types/run-state.js';
+
+function tempBase(): string {
+  return join(tmpdir(), `kata-run-test-${randomUUID()}`);
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    cycleId: randomUUID(),
+    betId: randomUUID(),
+    betPrompt: 'Implement auth',
+    kataPattern: 'full-feature',
+    stageSequence: ['research', 'plan', 'build'],
+    currentStage: 'research',
+    status: 'running',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('registerRunCommands — run status', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerRunCommands(program);
+    return program;
+  }
+
+  it('outputs human-readable status for a fresh run', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--cwd', baseDir, 'run', 'status', run.id]);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain(run.id);
+    expect(output).toContain('full-feature');
+    expect(output).toContain('RESEARCH');
+    expect(output).toContain('PLAN');
+    expect(output).toContain('BUILD');
+  });
+
+  it('outputs JSON status with --json flag', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--json', '--cwd', baseDir, 'run', 'status', run.id]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.run.id).toBe(run.id);
+    expect(parsed.stages).toHaveLength(3);
+    expect(parsed.stages.map((s: { category: string }) => s.category)).toEqual(['research', 'plan', 'build']);
+    expect(parsed.totalDecisions).toBe(0);
+    expect(parsed.totalArtifacts).toBe(0);
+  });
+
+  it('shows stage status in JSON output', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    // Advance research stage
+    writeStageState(runsDir, run.id, {
+      category: 'research',
+      status: 'running',
+      selectedFlavors: ['technical-research', 'codebase-analysis'],
+      executionMode: 'parallel',
+      gaps: [{ description: 'No security flavor', severity: 'medium' as const }],
+      decisions: [],
+    });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--json', '--cwd', baseDir, 'run', 'status', run.id]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    const researchStage = parsed.stages.find((s: { category: string }) => s.category === 'research');
+    expect(researchStage.status).toBe('running');
+    expect(researchStage.executionMode).toBe('parallel');
+    expect(researchStage.selectedFlavors).toEqual(['technical-research', 'codebase-analysis']);
+    expect(researchStage.gaps).toEqual([{ description: 'No security flavor', severity: 'medium' }]);
+  });
+
+  it('shows decisions with confidence in JSON output when decisions exist', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    // Record a decision via the decision command
+    const decisionProgram = new Command();
+    decisionProgram.option('--json').option('--verbose').option('--cwd <path>');
+    decisionProgram.exitOverride();
+    registerDecisionCommands(decisionProgram);
+
+    await decisionProgram.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--context', '{}',
+      '--options', '["a","b"]',
+      '--selected', 'a',
+      '--confidence', '0.85',
+      '--reasoning', 'Test',
+    ]);
+
+    consoleSpy.mockClear();
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--json', '--cwd', baseDir, 'run', 'status', run.id]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.totalDecisions).toBe(1);
+    const researchStage = parsed.stages.find((s: { category: string }) => s.category === 'research');
+    expect(researchStage.decisionCount).toBe(1);
+    expect(researchStage.avgConfidence).toBeCloseTo(0.85);
+  });
+
+  it('errors on unknown run ID', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--cwd', baseDir, 'run', 'status', randomUUID()]);
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,0 +1,245 @@
+import { existsSync } from 'node:fs';
+import type { Command } from 'commander';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+import { JsonlStore } from '@infra/persistence/jsonl-store.js';
+import {
+  readRun,
+  readStageState,
+  readFlavorState,
+  runPaths,
+} from '@infra/persistence/run-store.js';
+import {
+  ArtifactIndexEntrySchema,
+  DecisionEntrySchema,
+  DecisionOutcomeEntrySchema,
+  type Gap,
+  type StageState,
+  type FlavorState,
+  type Run,
+  type DecisionEntry,
+  type DecisionOutcomeEntry,
+} from '@domain/types/run-state.js';
+import type { StageCategory } from '@domain/types/stage.js';
+
+// ---------------------------------------------------------------------------
+// Types for the aggregated run status payload
+// ---------------------------------------------------------------------------
+
+interface FlavorSummary {
+  name: string;
+  status: string;
+  stepCount: number;
+  completedSteps: number;
+  currentStep: number | null;
+  artifactCount: number;
+}
+
+interface StageSummary {
+  category: StageCategory;
+  status: string;
+  executionMode: string | undefined;
+  selectedFlavors: string[];
+  gaps: Gap[];
+  decisionCount: number;
+  avgConfidence: number | null;
+  artifactCount: number;
+  flavors: FlavorSummary[];
+  hasSynthesis: boolean;
+}
+
+interface RunStatus {
+  run: Run;
+  stages: StageSummary[];
+  totalDecisions: number;
+  totalArtifacts: number;
+  decisions: Array<DecisionEntry & { latestOutcome: DecisionOutcomeEntry | undefined }>;
+}
+
+// ---------------------------------------------------------------------------
+// Status aggregation
+// ---------------------------------------------------------------------------
+
+function aggregateRunStatus(runsDir: string, runId: string): RunStatus {
+  const run = readRun(runsDir, runId);
+  const paths = runPaths(runsDir, runId);
+
+  const decisions = JsonlStore.readDecisionsWithOutcomes(
+    paths.decisionsJsonl,
+    paths.decisionOutcomesJsonl,
+    DecisionEntrySchema,
+    DecisionOutcomeEntrySchema,
+  );
+
+  const runArtifacts = JsonlStore.readAll(paths.artifactIndexJsonl, ArtifactIndexEntrySchema);
+
+  const stages: StageSummary[] = [];
+
+  for (const category of run.stageSequence) {
+    let stageState: StageState;
+    try {
+      stageState = readStageState(runsDir, runId, category);
+    } catch {
+      // Stage may not have been initialized yet
+      stageState = {
+        category,
+        status: 'pending',
+        selectedFlavors: [],
+        gaps: [],
+        decisions: [],
+      };
+    }
+
+    const stageDecisions = decisions.filter((d) => d.stageCategory === category);
+    const stageArtifacts = runArtifacts.filter((a) => a.stageCategory === category);
+
+    const avgConfidence =
+      stageDecisions.length > 0
+        ? stageDecisions.reduce((sum, d) => sum + d.confidence, 0) / stageDecisions.length
+        : null;
+
+    // Collect flavor summaries
+    const flavors: FlavorSummary[] = [];
+    for (const flavorName of stageState.selectedFlavors) {
+      let flavorState: FlavorState | undefined;
+      try {
+        flavorState = readFlavorState(runsDir, runId, category, flavorName);
+      } catch {
+        // Flavor state not initialized yet
+      }
+
+      const flavorArtifacts = stageArtifacts.filter((a) => a.flavor === flavorName);
+
+      flavors.push({
+        name: flavorName,
+        status: flavorState?.status ?? 'pending',
+        stepCount: flavorState?.steps.length ?? 0,
+        completedSteps: flavorState?.steps.filter((s) => s.status === 'completed').length ?? 0,
+        currentStep: flavorState?.currentStep ?? null,
+        artifactCount: flavorArtifacts.length,
+      });
+    }
+
+    const hasSynthesis = existsSync(paths.stageSynthesis(category)) ||
+      stageState.synthesisArtifact !== undefined;
+
+    stages.push({
+      category,
+      status: stageState.status,
+      executionMode: stageState.executionMode,
+      selectedFlavors: stageState.selectedFlavors,
+      gaps: stageState.gaps,
+      decisionCount: stageDecisions.length,
+      avgConfidence,
+      artifactCount: stageArtifacts.length,
+      flavors,
+      hasSynthesis,
+    });
+  }
+
+  return {
+    run,
+    stages,
+    totalDecisions: decisions.length,
+    totalArtifacts: runArtifacts.length,
+    decisions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const STATUS_ICONS: Record<string, string> = {
+  pending: '○',
+  running: '●',
+  completed: '✓',
+  failed: '✗',
+  skipped: '–',
+};
+
+function formatRunStatus(status: RunStatus): string {
+  const { run, stages } = status;
+  const lines: string[] = [];
+
+  const runIcon = STATUS_ICONS[run.status] ?? '?';
+  lines.push(`${runIcon} Run: ${run.id}`);
+  lines.push(`  Status:   ${run.status}`);
+  lines.push(`  Bet:      ${run.betPrompt}`);
+  if (run.kataPattern) lines.push(`  Pattern:  ${run.kataPattern}`);
+  lines.push(`  Sequence: ${run.stageSequence.join(' → ')}`);
+  if (run.currentStage) lines.push(`  Current:  ${run.currentStage}`);
+  lines.push(`  Decisions: ${status.totalDecisions}   Artifacts: ${status.totalArtifacts}`);
+  lines.push('');
+
+  for (const stage of stages) {
+    const icon = STATUS_ICONS[stage.status] ?? '?';
+    const modeStr = stage.executionMode ? ` [${stage.executionMode}]` : '';
+    lines.push(`${icon} ${stage.category.toUpperCase()}${modeStr}`);
+
+    if (stage.selectedFlavors.length > 0) {
+      for (const flavor of stage.flavors) {
+        const fIcon = STATUS_ICONS[flavor.status] ?? '?';
+        const progress = flavor.stepCount > 0 ? ` (${flavor.completedSteps}/${flavor.stepCount} steps)` : '';
+        lines.push(`    ${fIcon} ${flavor.name}${progress} — ${flavor.artifactCount} artifact(s)`);
+      }
+    }
+
+    if (stage.hasSynthesis) {
+      lines.push(`    ✓ synthesis artifact`);
+    }
+
+    if (stage.gaps.length > 0) {
+      for (const gap of stage.gaps) {
+        lines.push(`    ⚠ gap [${gap.severity}]: ${gap.description}`);
+      }
+    }
+
+    if (stage.decisionCount > 0) {
+      const confStr = stage.avgConfidence !== null
+        ? ` (avg confidence: ${stage.avgConfidence.toFixed(2)})`
+        : '';
+      lines.push(`    Decisions: ${stage.decisionCount}${confStr}`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerRunCommands(parent: Command): void {
+  const run = parent
+    .command('run')
+    .description('Inspect kata run state');
+
+  // kata run status <run-id>
+  run
+    .command('status <run-id>')
+    .description('Show the status of a run (human-readable or --json)')
+    .action(withCommandContext((ctx, runId: string) => {
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+
+      const status = aggregateRunStatus(runsDir, runId);
+
+      if (ctx.globalOpts.json) {
+        // JSON output: include full decision list for agent consumption
+        const payload = {
+          run: status.run,
+          stages: status.stages,
+          totalDecisions: status.totalDecisions,
+          totalArtifacts: status.totalArtifacts,
+          decisions: status.decisions.map((d) => ({
+            ...d,
+            outcome: d.latestOutcome,
+          })),
+        };
+        console.log(JSON.stringify(payload, null, 2));
+      } else {
+        console.log(formatRunStatus(status));
+      }
+    }));
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,6 +8,9 @@ import { registerCycleCommands } from './commands/cycle.js';
 import { registerKnowledgeCommands } from './commands/knowledge.js';
 import { registerExecuteCommands } from './commands/execute.js';
 import { registerStatusCommands } from './commands/status.js';
+import { registerArtifactCommands } from './commands/artifact.js';
+import { registerDecisionCommands } from './commands/decision.js';
+import { registerRunCommands } from './commands/run.js';
 
 const VERSION = '0.1.0';
 
@@ -39,6 +42,9 @@ export function createProgram(): Command {
   registerKnowledgeCommands(program);
   registerExecuteCommands(program);
   registerStatusCommands(program);
+  registerArtifactCommands(program);
+  registerDecisionCommands(program);
+  registerRunCommands(program);
 
   return program;
 }

--- a/src/domain/types/bet.ts
+++ b/src/domain/types/bet.ts
@@ -1,8 +1,21 @@
 import { z } from 'zod/v4';
+import { StageCategorySchema } from './stage.js';
 
 export const BetOutcome = z.enum(['pending', 'complete', 'partial', 'abandoned']);
 
 export type BetOutcome = z.infer<typeof BetOutcome>;
+
+/**
+ * How a bet is assigned to a kata execution pattern.
+ * named: uses a saved kata sequence by pattern name.
+ * ad-hoc: explicitly specifies stage categories to run.
+ */
+export const KataAssignmentSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('named'), pattern: z.string().min(1) }),
+  z.object({ type: z.literal('ad-hoc'), stages: z.array(StageCategorySchema).min(1) }),
+]);
+
+export type KataAssignment = z.infer<typeof KataAssignmentSchema>;
 
 export const BetSchema = z.object({
   id: z.string().uuid(),
@@ -15,6 +28,8 @@ export const BetSchema = z.object({
   issueRefs: z.array(z.string()).default([]),
   outcome: BetOutcome.default('pending'),
   outcomeNotes: z.string().optional(),
+  /** Kata execution assignment for this bet. Required by `kata cycle start`. */
+  kata: KataAssignmentSchema.optional(),
 });
 
 export type Bet = z.infer<typeof BetSchema>;

--- a/src/domain/types/run-state.test.ts
+++ b/src/domain/types/run-state.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RunSchema,
+  StageStateSchema,
+  FlavorStateSchema,
+  FlavorStepRunSchema,
+  DecisionEntrySchema,
+  DecisionOutcomeEntrySchema,
+  ArtifactIndexEntrySchema,
+} from './run-state.js';
+
+const VALID_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const VALID_TS = '2026-01-01T00:00:00.000Z';
+
+describe('RunSchema', () => {
+  const minimal = {
+    id: VALID_UUID,
+    cycleId: VALID_UUID,
+    betId: VALID_UUID,
+    betPrompt: 'Implement auth',
+    stageSequence: ['research', 'plan'],
+    currentStage: null,
+    status: 'pending',
+    startedAt: VALID_TS,
+  };
+
+  it('parses a minimal valid run', () => {
+    const result = RunSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a full run with optional fields', () => {
+    const full = {
+      ...minimal,
+      kataPattern: 'full-feature',
+      currentStage: 'research',
+      status: 'running',
+      completedAt: VALID_TS,
+    };
+    const result = RunSchema.safeParse(full);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty stageSequence', () => {
+    const result = RunSchema.safeParse({ ...minimal, stageSequence: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid status', () => {
+    const result = RunSchema.safeParse({ ...minimal, status: 'unknown' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid stage in stageSequence', () => {
+    const result = RunSchema.safeParse({ ...minimal, stageSequence: ['research', 'deploy'] });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('StageStateSchema', () => {
+  const minimal = {
+    category: 'research',
+    status: 'pending',
+  };
+
+  it('parses minimal stage state (arrays default to [])', () => {
+    const result = StageStateSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.selectedFlavors).toEqual([]);
+      expect(result.data.gaps).toEqual([]);
+      expect(result.data.decisions).toEqual([]);
+    }
+  });
+
+  it('parses full stage state', () => {
+    const full = {
+      category: 'plan',
+      status: 'running',
+      selectedFlavors: ['architecture', 'task-breakdown'],
+      executionMode: 'parallel',
+      gaps: [{ description: 'No security flavor', severity: 'medium' }],
+      synthesisArtifact: 'stages/plan/synthesis.md',
+      decisions: [VALID_UUID],
+      startedAt: VALID_TS,
+      completedAt: VALID_TS,
+    };
+    const result = StageStateSchema.safeParse(full);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid executionMode', () => {
+    const result = StageStateSchema.safeParse({ ...minimal, executionMode: 'random' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('FlavorStateSchema', () => {
+  const minimal = {
+    name: 'technical-research',
+    stageCategory: 'research',
+    status: 'pending',
+    currentStep: null,
+  };
+
+  it('parses minimal flavor state (steps defaults to [])', () => {
+    const result = FlavorStateSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.steps).toEqual([]);
+    }
+  });
+
+  it('parses flavor with steps', () => {
+    const full = {
+      ...minimal,
+      status: 'running',
+      currentStep: 0,
+      steps: [
+        {
+          type: 'gather-context',
+          status: 'completed',
+          artifacts: ['context.md'],
+          startedAt: VALID_TS,
+          completedAt: VALID_TS,
+        },
+        { type: 'deep-dive', status: 'running', startedAt: VALID_TS },
+      ],
+    };
+    const result = FlavorStateSchema.safeParse(full);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative currentStep', () => {
+    const result = FlavorStateSchema.safeParse({ ...minimal, currentStep: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('FlavorStepRunSchema', () => {
+  it('parses minimal step run (artifacts defaults to [])', () => {
+    const result = FlavorStepRunSchema.safeParse({ type: 'build', status: 'pending' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.artifacts).toEqual([]);
+    }
+  });
+
+  it('rejects empty type', () => {
+    const result = FlavorStepRunSchema.safeParse({ type: '', status: 'pending' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('DecisionEntrySchema', () => {
+  const valid = {
+    id: VALID_UUID,
+    stageCategory: 'research',
+    flavor: 'technical-research',
+    step: 'gather-context',
+    decisionType: 'flavor-selection',
+    context: { betType: 'auth' },
+    options: ['technical-research', 'codebase-analysis'],
+    selection: 'technical-research',
+    reasoning: 'Best match for auth bet',
+    confidence: 0.87,
+    decidedAt: VALID_TS,
+  };
+
+  it('parses a valid decision entry', () => {
+    const result = DecisionEntrySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('allows null flavor and step', () => {
+    const result = DecisionEntrySchema.safeParse({ ...valid, flavor: null, step: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects confidence > 1', () => {
+    const result = DecisionEntrySchema.safeParse({ ...valid, confidence: 1.1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts empty options array (gap-assessment decisions may have no discrete options)', () => {
+    const result = DecisionEntrySchema.safeParse({ ...valid, options: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts arbitrary decisionType strings (open vocabulary)', () => {
+    const result = DecisionEntrySchema.safeParse({ ...valid, decisionType: 'custom-judgment' });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('DecisionOutcomeEntrySchema', () => {
+  const valid = {
+    decisionId: VALID_UUID,
+    outcome: 'good',
+    notes: 'Worked perfectly',
+    updatedAt: VALID_TS,
+  };
+
+  it('parses a valid outcome entry', () => {
+    const result = DecisionOutcomeEntrySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses without optional fields', () => {
+    const result = DecisionOutcomeEntrySchema.safeParse({
+      decisionId: VALID_UUID,
+      outcome: 'unknown',
+      updatedAt: VALID_TS,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid outcome value', () => {
+    const result = DecisionOutcomeEntrySchema.safeParse({ ...valid, outcome: 'excellent' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ArtifactIndexEntrySchema', () => {
+  const valid = {
+    id: VALID_UUID,
+    stageCategory: 'build',
+    flavor: 'tdd',
+    step: 'write-tests',
+    fileName: 'tests.md',
+    filePath: '/abs/path/tests.md',
+    summary: 'Unit tests for auth module',
+    type: 'artifact',
+    recordedAt: VALID_TS,
+  };
+
+  it('parses a valid artifact index entry', () => {
+    const result = ArtifactIndexEntrySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses synthesis type with null step', () => {
+    const result = ArtifactIndexEntrySchema.safeParse({ ...valid, step: null, type: 'synthesis' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid type', () => {
+    const result = ArtifactIndexEntrySchema.safeParse({ ...valid, type: 'report' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty fileName', () => {
+    const result = ArtifactIndexEntrySchema.safeParse({ ...valid, fileName: '' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/domain/types/run-state.ts
+++ b/src/domain/types/run-state.ts
@@ -1,0 +1,252 @@
+import { z } from 'zod/v4';
+import { StageCategorySchema } from './stage.js';
+
+// ---------------------------------------------------------------------------
+// Status enums
+// ---------------------------------------------------------------------------
+
+export const RunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed']);
+export type RunStatus = z.infer<typeof RunStatusSchema>;
+
+export const StageStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'skipped']);
+export type StageStatus = z.infer<typeof StageStatusSchema>;
+
+export const FlavorStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'skipped']);
+export type FlavorStatus = z.infer<typeof FlavorStatusSchema>;
+
+export const StepRunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'skipped']);
+export type StepRunStatus = z.infer<typeof StepRunStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// run.json — overall run state
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level run record stored at .kata/runs/<run-id>/run.json.
+ * Created by `kata cycle start` for each bet; tracks the big-picture state
+ * of a single bet's execution through its kata stage sequence.
+ */
+export const RunSchema = z.object({
+  /** UUID for this run. */
+  id: z.string().uuid(),
+  /** ID of the cycle that owns this run. */
+  cycleId: z.string().uuid(),
+  /** ID of the bet this run is executing. */
+  betId: z.string().uuid(),
+  /** The original bet prompt / description. */
+  betPrompt: z.string().min(1),
+  /** Named kata pattern (e.g. "full-feature") or undefined for ad-hoc. */
+  kataPattern: z.string().optional(),
+  /** Ordered stage categories the run will execute. */
+  stageSequence: z.array(StageCategorySchema).min(1),
+  /** The stage the run is currently executing, or null if not yet started. */
+  currentStage: StageCategorySchema.nullable(),
+  /** Overall run status. */
+  status: RunStatusSchema,
+  /** ISO 8601 timestamp when the run was created. */
+  startedAt: z.string().datetime(),
+  /** ISO 8601 timestamp when the run finished (completed or failed). */
+  completedAt: z.string().datetime().optional(),
+});
+
+export type Run = z.infer<typeof RunSchema>;
+
+// ---------------------------------------------------------------------------
+// Stage state.json
+// ---------------------------------------------------------------------------
+
+/**
+ * A gap identified by the orchestrator's gap-analysis phase.
+ * Stored in StageState.gaps so the TUI, reflect phase, and cooldown can
+ * display and act on gap severity independently.
+ */
+export const GapSchema = z.object({
+  /** Human-readable description of the gap. */
+  description: z.string().min(1),
+  /** Severity level, used for TUI display and prioritization. */
+  severity: z.enum(['low', 'medium', 'high']),
+});
+
+export type Gap = z.infer<typeof GapSchema>;
+
+/**
+ * A pending gate blocking stage or flavor progress.
+ * Written when an entry/exit gate is triggered; cleared on approval.
+ * `kata approve` reads and clears this field; `kata run status` surfaces it.
+ */
+export const PendingGateSchema = z.object({
+  /** Short unique identifier used by `kata approve`. */
+  gateId: z.string().min(1),
+  /** Gate type descriptor (e.g. "human-approved", "confidence-gate"). */
+  gateType: z.string().min(1),
+  /**
+   * What is blocked by this gate — a flavor name, step name, or "stage"
+   * for a stage-level gate.
+   */
+  requiredBy: z.string().min(1),
+});
+
+export type PendingGate = z.infer<typeof PendingGateSchema>;
+
+/**
+ * Per-stage state stored at .kata/runs/<run-id>/stages/<category>/state.json.
+ */
+export const StageStateSchema = z.object({
+  /** Which stage category this represents. */
+  category: StageCategorySchema,
+  /** Stage execution status. */
+  status: StageStatusSchema,
+  /** Flavors selected by the orchestrator for this stage. */
+  selectedFlavors: z.array(z.string()).default([]),
+  /** How flavors are being run: parallel or sequential. */
+  executionMode: z.enum(['parallel', 'sequential']).optional(),
+  /** Gap analysis findings from the orchestrator's gap-assessment phase. */
+  gaps: z.array(GapSchema).default([]),
+  /** Path to the stage-level synthesis artifact (relative to run dir). */
+  synthesisArtifact: z.string().optional(),
+  /** Decision IDs recorded during this stage. */
+  decisions: z.array(z.string().uuid()).default([]),
+  /**
+   * Gate currently blocking this stage, if any.
+   * Set when a gate triggers; cleared by `kata approve`.
+   */
+  pendingGate: PendingGateSchema.optional(),
+  /** ISO 8601 timestamp when this stage started. */
+  startedAt: z.string().datetime().optional(),
+  /** ISO 8601 timestamp when this stage finished. */
+  completedAt: z.string().datetime().optional(),
+});
+
+export type StageState = z.infer<typeof StageStateSchema>;
+
+// ---------------------------------------------------------------------------
+// Flavor state.json
+// ---------------------------------------------------------------------------
+
+/** Per-step execution record within a flavor. */
+export const FlavorStepRunSchema = z.object({
+  /** Step type identifier (matches Step.type). */
+  type: z.string().min(1),
+  /** Execution status of this step. */
+  status: StepRunStatusSchema,
+  /** Relative paths to artifacts produced by this step. */
+  artifacts: z.array(z.string()).default([]),
+  /** ISO 8601 timestamp when this step started. */
+  startedAt: z.string().datetime().optional(),
+  /** ISO 8601 timestamp when this step finished. */
+  completedAt: z.string().datetime().optional(),
+});
+
+export type FlavorStepRun = z.infer<typeof FlavorStepRunSchema>;
+
+/**
+ * Per-flavor state stored at .kata/runs/<run-id>/stages/<category>/flavors/<name>/state.json.
+ */
+export const FlavorStateSchema = z.object({
+  /** Flavor name (matches Flavor.name). */
+  name: z.string().min(1),
+  /** Stage category this flavor belongs to. */
+  stageCategory: StageCategorySchema,
+  /** Flavor execution status. */
+  status: FlavorStatusSchema,
+  /** Ordered step execution records. */
+  steps: z.array(FlavorStepRunSchema).default([]),
+  /** Index of the currently executing step, or null if none. */
+  currentStep: z.number().int().nonnegative().nullable(),
+});
+
+export type FlavorState = z.infer<typeof FlavorStateSchema>;
+
+// ---------------------------------------------------------------------------
+// decisions.jsonl entries
+// ---------------------------------------------------------------------------
+
+/**
+ * An entry appended to decisions.jsonl.
+ * Immutable once written — outcomes are recorded in decision-outcomes.jsonl.
+ */
+export const DecisionEntrySchema = z.object({
+  /** UUID generated at record time. */
+  id: z.string().uuid(),
+  /** Which stage the decision was made in. */
+  stageCategory: StageCategorySchema,
+  /** Which flavor the decision belongs to (nullable for stage-level decisions). */
+  flavor: z.string().nullable(),
+  /** Which step the decision belongs to (nullable for flavor/stage-level decisions). */
+  step: z.string().nullable(),
+  /** Category of judgment being made (open string — warns on unknown). */
+  decisionType: z.string().min(1),
+  /** Contextual snapshot at decision time. */
+  context: z.record(z.string(), z.unknown()),
+  /** Available options the orchestrator considered. */
+  options: z.array(z.string()),
+  /** The chosen option. */
+  selection: z.string().min(1),
+  /** Orchestrator's reasoning for the selection. */
+  reasoning: z.string().min(1),
+  /** Confidence in the selection: [0, 1]. */
+  confidence: z.number().min(0).max(1),
+  /** ISO 8601 timestamp when the decision was made. */
+  decidedAt: z.string().datetime(),
+});
+
+export type DecisionEntry = z.infer<typeof DecisionEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// decision-outcomes.jsonl entries
+// ---------------------------------------------------------------------------
+
+/**
+ * An entry appended to decision-outcomes.jsonl.
+ * Companion file to decisions.jsonl — preserves the append-only decision log
+ * while still allowing retrospective outcome recording.
+ * Latest entry per decisionId wins on merge.
+ */
+export const DecisionOutcomeEntrySchema = z.object({
+  /** UUID of the decision being annotated. */
+  decisionId: z.string().uuid(),
+  /** Quality assessment of the decision's outcome. */
+  outcome: z.enum(['good', 'partial', 'poor', 'unknown']),
+  /** Free-text notes about the outcome. */
+  notes: z.string().optional(),
+  /** JSON string of user overrides applied to the decision. */
+  userOverrides: z.string().optional(),
+  /** ISO 8601 timestamp when this outcome was recorded. */
+  updatedAt: z.string().datetime(),
+});
+
+export type DecisionOutcomeEntry = z.infer<typeof DecisionOutcomeEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// artifact-index.jsonl entries
+// ---------------------------------------------------------------------------
+
+/** Whether the artifact is a step output or a flavor/stage-level synthesis. */
+export const ArtifactIndexTypeSchema = z.enum(['artifact', 'synthesis']);
+export type ArtifactIndexType = z.infer<typeof ArtifactIndexTypeSchema>;
+
+/**
+ * An entry appended to artifact-index.jsonl (run-level and flavor-level).
+ */
+export const ArtifactIndexEntrySchema = z.object({
+  /** UUID generated at record time. */
+  id: z.string().uuid(),
+  /** Stage the artifact was produced in. */
+  stageCategory: StageCategorySchema,
+  /** Flavor that produced the artifact. */
+  flavor: z.string().min(1),
+  /** Step that produced the artifact (nullable for synthesis artifacts). */
+  step: z.string().nullable(),
+  /** Filename of the artifact (basename only). */
+  fileName: z.string().min(1),
+  /** Absolute path to the artifact on disk. */
+  filePath: z.string().min(1),
+  /** Short human-readable summary of the artifact's content. */
+  summary: z.string().min(1),
+  /** Whether this is a step-level artifact or a synthesis product. */
+  type: ArtifactIndexTypeSchema,
+  /** ISO 8601 timestamp when the artifact was recorded. */
+  recordedAt: z.string().datetime(),
+});
+
+export type ArtifactIndexEntry = z.infer<typeof ArtifactIndexEntrySchema>;

--- a/src/infrastructure/persistence/jsonl-store.test.ts
+++ b/src/infrastructure/persistence/jsonl-store.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod/v4';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { JsonlStore, JsonlStoreError } from './jsonl-store.js';
+
+const WidgetSchema = z.object({ id: z.string(), value: z.number() });
+type Widget = z.infer<typeof WidgetSchema>;
+
+const OutcomeSchema = z.object({ decisionId: z.string(), result: z.string(), updatedAt: z.string() });
+
+function tempDir(): string {
+  const dir = join(tmpdir(), `kata-jsonl-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('JsonlStore.append', () => {
+  it('creates file and appends an entry', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+
+    JsonlStore.append(path, { id: 'a', value: 1 }, WidgetSchema);
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({ id: 'a', value: 1 });
+  });
+
+  it('appends multiple entries', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+
+    JsonlStore.append(path, { id: 'a', value: 1 }, WidgetSchema);
+    JsonlStore.append(path, { id: 'b', value: 2 }, WidgetSchema);
+    JsonlStore.append(path, { id: 'c', value: 3 }, WidgetSchema);
+
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('creates parent directories if missing', () => {
+    const dir = tempDir();
+    const path = join(dir, 'nested', 'deeply', 'widgets.jsonl');
+
+    JsonlStore.append(path, { id: 'a', value: 1 }, WidgetSchema);
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(1);
+  });
+
+  it('throws JsonlStoreError on validation failure', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+
+    expect(() =>
+      JsonlStore.append(path, { id: 'a', value: 'not-a-number' } as unknown as Widget, WidgetSchema)
+    ).toThrow(JsonlStoreError);
+  });
+});
+
+describe('JsonlStore.readAll', () => {
+  it('returns empty array for missing file', () => {
+    const dir = tempDir();
+    const path = join(dir, 'nonexistent.jsonl');
+    expect(JsonlStore.readAll(path, WidgetSchema)).toEqual([]);
+  });
+
+  it('skips blank lines', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+    writeFileSync(path, '\n{"id":"a","value":1}\n\n{"id":"b","value":2}\n', 'utf-8');
+
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('skips invalid JSON lines without throwing', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+    writeFileSync(path, '{"id":"a","value":1}\nnot-json\n{"id":"b","value":2}\n', 'utf-8');
+
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('skips lines failing schema validation without throwing', () => {
+    const dir = tempDir();
+    const path = join(dir, 'widgets.jsonl');
+    writeFileSync(path, '{"id":"a","value":1}\n{"id":"b","value":"bad"}\n', 'utf-8');
+
+    const entries = JsonlStore.readAll(path, WidgetSchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('a');
+  });
+});
+
+describe('JsonlStore.readDecisionsWithOutcomes', () => {
+  function writeJsonl(path: string, entries: unknown[]): void {
+    const dir = join(path, '..');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path, entries.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  }
+
+  it('returns decisions with no outcomes when outcome file is missing', () => {
+    const dir = tempDir();
+    const decisionsPath = join(dir, 'decisions.jsonl');
+    const outcomesPath = join(dir, 'decision-outcomes.jsonl');
+
+    writeJsonl(decisionsPath, [{ id: 'w1', value: 10, decidedAt: '2026-01-01T00:00:00.000Z' }]);
+
+    const results = JsonlStore.readDecisionsWithOutcomes(
+      decisionsPath,
+      outcomesPath,
+      WidgetSchema.extend({ decidedAt: z.string() }),
+      OutcomeSchema,
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].latestOutcome).toBeUndefined();
+  });
+
+  it('merges latest outcome per decision ID', () => {
+    const dir = tempDir();
+    const decisionsPath = join(dir, 'decisions.jsonl');
+    const outcomesPath = join(dir, 'decision-outcomes.jsonl');
+
+    writeJsonl(decisionsPath, [
+      { id: 'w1', value: 10, decidedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'w2', value: 20, decidedAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+    writeJsonl(outcomesPath, [
+      { decisionId: 'w1', result: 'first', updatedAt: '2026-01-01T01:00:00.000Z' },
+      { decisionId: 'w1', result: 'second', updatedAt: '2026-01-01T02:00:00.000Z' },
+      { decisionId: 'w2', result: 'only', updatedAt: '2026-01-01T01:00:00.000Z' },
+    ]);
+
+    const results = JsonlStore.readDecisionsWithOutcomes(
+      decisionsPath,
+      outcomesPath,
+      WidgetSchema.extend({ decidedAt: z.string() }),
+      OutcomeSchema,
+    );
+
+    expect(results).toHaveLength(2);
+    const w1 = results.find((r) => r.id === 'w1');
+    expect(w1?.latestOutcome?.result).toBe('second'); // Latest by updatedAt
+    const w2 = results.find((r) => r.id === 'w2');
+    expect(w2?.latestOutcome?.result).toBe('only');
+  });
+
+  it('preserves decision order', () => {
+    const dir = tempDir();
+    const decisionsPath = join(dir, 'decisions.jsonl');
+    const outcomesPath = join(dir, 'decision-outcomes.jsonl');
+
+    writeJsonl(decisionsPath, [
+      { id: 'w3', value: 30, decidedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'w1', value: 10, decidedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'w2', value: 20, decidedAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+
+    const results = JsonlStore.readDecisionsWithOutcomes(
+      decisionsPath,
+      outcomesPath,
+      WidgetSchema.extend({ decidedAt: z.string() }),
+      OutcomeSchema,
+    );
+
+    expect(results.map((r) => r.id)).toEqual(['w3', 'w1', 'w2']);
+  });
+});

--- a/src/infrastructure/persistence/jsonl-store.ts
+++ b/src/infrastructure/persistence/jsonl-store.ts
@@ -1,0 +1,132 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { z } from 'zod/v4';
+import { logger } from '@shared/lib/logger.js';
+
+export class JsonlStoreError extends Error {
+  constructor(
+    message: string,
+    public readonly path: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'JsonlStoreError';
+  }
+}
+
+/**
+ * Append-only JSONL (newline-delimited JSON) file persistence.
+ *
+ * Each line in a JSONL file is an independent JSON object.
+ * Invalid lines are skipped with a warning on read.
+ * Files are created on first append.
+ */
+export const JsonlStore = {
+  /**
+   * Append a single entry to a JSONL file.
+   * Creates the file and parent directories if they don't exist.
+   */
+  append<T>(path: string, entry: T, schema: z.ZodType<T>): void {
+    const result = schema.safeParse(entry);
+    if (!result.success) {
+      throw new JsonlStoreError(
+        `Validation failed before append: ${JSON.stringify(result.error.issues, null, 2)}`,
+        path,
+        result.error,
+      );
+    }
+
+    const dir = dirname(path);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    try {
+      appendFileSync(path, JSON.stringify(result.data) + '\n', 'utf-8');
+    } catch (err) {
+      throw new JsonlStoreError(`Failed to append to file: ${path}`, path, err);
+    }
+  },
+
+  /**
+   * Read all valid entries from a JSONL file.
+   * Lines that fail parsing or validation are skipped with a warning.
+   * Returns an empty array if the file does not exist.
+   */
+  readAll<T>(path: string, schema: z.ZodType<T>): T[] {
+    if (!existsSync(path)) {
+      return [];
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf-8');
+    } catch (err) {
+      throw new JsonlStoreError(`Failed to read file: ${path}`, path, err);
+    }
+
+    const results: T[] = [];
+
+    for (const [lineIndex, line] of raw.split('\n').entries()) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        logger.warn(`Skipping invalid JSON on line ${lineIndex + 1} in ${path}`);
+        continue;
+      }
+
+      const result = schema.safeParse(parsed);
+      if (!result.success) {
+        logger.warn(`Skipping invalid entry on line ${lineIndex + 1} in ${path}`, {
+          issues: result.error.issues,
+        });
+        continue;
+      }
+
+      results.push(result.data);
+    }
+
+    return results;
+  },
+
+  /**
+   * Read decisions.jsonl and decision-outcomes.jsonl and merge them.
+   * For each decision, the latest outcome entry (by updatedAt) is merged in.
+   * Returns the merged entries in original decision order.
+   *
+   * @param decisionsPath Path to decisions.jsonl
+   * @param outcomesPath Path to decision-outcomes.jsonl
+   * @param decisionSchema Zod schema for decision entries (must have id, decidedAt)
+   * @param outcomeSchema Zod schema for outcome entries (must have decisionId, updatedAt)
+   */
+  readDecisionsWithOutcomes<
+    D extends { id: string; decidedAt: string },
+    O extends { decisionId: string; updatedAt: string },
+  >(
+    decisionsPath: string,
+    outcomesPath: string,
+    decisionSchema: z.ZodType<D>,
+    outcomeSchema: z.ZodType<O>,
+  ): Array<D & { latestOutcome: O | undefined }> {
+    const decisions = JsonlStore.readAll(decisionsPath, decisionSchema);
+    const outcomes = JsonlStore.readAll(outcomesPath, outcomeSchema);
+
+    // Build a map: decisionId → latest outcome (by updatedAt)
+    const latestOutcomeByDecisionId = new Map<string, O>();
+    for (const outcome of outcomes) {
+      const existing = latestOutcomeByDecisionId.get(outcome.decisionId);
+      if (!existing || outcome.updatedAt > existing.updatedAt) {
+        latestOutcomeByDecisionId.set(outcome.decisionId, outcome);
+      }
+    }
+
+    return decisions.map((d) => ({
+      ...d,
+      latestOutcome: latestOutcomeByDecisionId.get(d.id),
+    }));
+  },
+};

--- a/src/infrastructure/persistence/run-store.test.ts
+++ b/src/infrastructure/persistence/run-store.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import {
+  createRunTree,
+  readRun,
+  writeRun,
+  readStageState,
+  writeStageState,
+  readFlavorState,
+  writeFlavorState,
+  runPaths,
+} from './run-store.js';
+import type { Run } from '@domain/types/run-state.js';
+import { existsSync } from 'node:fs';
+
+const VALID_UUID = () => randomUUID();
+const VALID_TS = '2026-01-01T00:00:00.000Z';
+
+function tempRunsDir(): string {
+  const dir = join(tmpdir(), `kata-run-store-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: VALID_UUID(),
+    cycleId: VALID_UUID(),
+    betId: VALID_UUID(),
+    betPrompt: 'Implement auth',
+    stageSequence: ['research', 'plan'],
+    currentStage: null,
+    status: 'pending',
+    startedAt: VALID_TS,
+    ...overrides,
+  };
+}
+
+describe('createRunTree', () => {
+  it('creates the run directory and run.json', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun();
+
+    createRunTree(runsDir, run);
+
+    const paths = runPaths(runsDir, run.id);
+    expect(existsSync(paths.runDir)).toBe(true);
+    expect(existsSync(paths.runJson)).toBe(true);
+  });
+
+  it('creates per-stage directories and state.json files', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun({ stageSequence: ['research', 'plan', 'build'] });
+
+    createRunTree(runsDir, run);
+
+    const paths = runPaths(runsDir, run.id);
+    for (const category of ['research', 'plan', 'build'] as const) {
+      expect(existsSync(paths.stageDir(category))).toBe(true);
+      expect(existsSync(paths.stateJson(category))).toBe(true);
+    }
+  });
+
+  it('round-trips run.json via readRun', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun({ kataPattern: 'full-feature', currentStage: 'research', status: 'running' });
+
+    createRunTree(runsDir, run);
+
+    const loaded = readRun(runsDir, run.id);
+    expect(loaded).toEqual(run);
+  });
+
+  it('initializes stage states as pending with empty arrays', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun();
+
+    createRunTree(runsDir, run);
+
+    const researchState = readStageState(runsDir, run.id, 'research');
+    expect(researchState.status).toBe('pending');
+    expect(researchState.selectedFlavors).toEqual([]);
+    expect(researchState.gaps).toEqual([]);
+    expect(researchState.decisions).toEqual([]);
+  });
+});
+
+describe('readRun / writeRun', () => {
+  it('round-trips run state updates', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const updated: Run = { ...run, status: 'running', currentStage: 'research' };
+    writeRun(runsDir, updated);
+
+    const loaded = readRun(runsDir, run.id);
+    expect(loaded.status).toBe('running');
+    expect(loaded.currentStage).toBe('research');
+  });
+});
+
+describe('readStageState / writeStageState', () => {
+  it('round-trips stage state updates', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    writeStageState(runsDir, run.id, {
+      category: 'research',
+      status: 'running',
+      selectedFlavors: ['technical-research'],
+      executionMode: 'parallel',
+      gaps: [{ description: 'No security flavor', severity: 'medium' as const }],
+      decisions: [VALID_UUID()],
+      startedAt: VALID_TS,
+    });
+
+    const state = readStageState(runsDir, run.id, 'research');
+    expect(state.status).toBe('running');
+    expect(state.selectedFlavors).toEqual(['technical-research']);
+    expect(state.executionMode).toBe('parallel');
+    expect(state.gaps).toHaveLength(1);
+  });
+});
+
+describe('readFlavorState / writeFlavorState', () => {
+  it('creates flavor directory on write and round-trips', () => {
+    const runsDir = tempRunsDir();
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const flavorState = {
+      name: 'technical-research',
+      stageCategory: 'research' as const,
+      status: 'running' as const,
+      steps: [{ type: 'gather-context', status: 'completed' as const, artifacts: ['ctx.md'] }],
+      currentStep: 0,
+    };
+
+    writeFlavorState(runsDir, run.id, 'research', flavorState);
+
+    const paths = runPaths(runsDir, run.id);
+    expect(existsSync(paths.flavorDir('research', 'technical-research'))).toBe(true);
+
+    const loaded = readFlavorState(runsDir, run.id, 'research', 'technical-research');
+    expect(loaded.name).toBe('technical-research');
+    expect(loaded.steps).toHaveLength(1);
+    expect(loaded.steps[0].artifacts).toEqual(['ctx.md']);
+  });
+});

--- a/src/infrastructure/persistence/run-store.ts
+++ b/src/infrastructure/persistence/run-store.ts
@@ -1,0 +1,142 @@
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { JsonStore } from './json-store.js';
+import {
+  RunSchema,
+  StageStateSchema,
+  FlavorStateSchema,
+  type Run,
+  type StageState,
+  type FlavorState,
+} from '@domain/types/run-state.js';
+import type { StageCategory } from '@domain/types/stage.js';
+
+/**
+ * Path helpers for the .kata/runs/ tree.
+ *
+ * Directory structure:
+ *   .kata/runs/<run-id>/
+ *     run.json
+ *     decisions.jsonl
+ *     decision-outcomes.jsonl
+ *     artifact-index.jsonl
+ *     stages/
+ *       <category>/
+ *         state.json
+ *         flavors/
+ *           <flavor-name>/
+ *             state.json
+ *             artifact-index.jsonl
+ *             artifacts/
+ *               <files>
+ *             synthesis.md  (optional)
+ */
+export function runPaths(runsDir: string, runId: string) {
+  const runDir = join(runsDir, runId);
+  return {
+    runDir,
+    runJson: join(runDir, 'run.json'),
+    decisionsJsonl: join(runDir, 'decisions.jsonl'),
+    decisionOutcomesJsonl: join(runDir, 'decision-outcomes.jsonl'),
+    artifactIndexJsonl: join(runDir, 'artifact-index.jsonl'),
+    stagesDir: join(runDir, 'stages'),
+    stageDir: (category: StageCategory) => join(runDir, 'stages', category),
+    stateJson: (category: StageCategory) => join(runDir, 'stages', category, 'state.json'),
+    flavorsDir: (category: StageCategory) => join(runDir, 'stages', category, 'flavors'),
+    flavorDir: (category: StageCategory, flavor: string) =>
+      join(runDir, 'stages', category, 'flavors', flavor),
+    flavorStateJson: (category: StageCategory, flavor: string) =>
+      join(runDir, 'stages', category, 'flavors', flavor, 'state.json'),
+    flavorArtifactIndexJsonl: (category: StageCategory, flavor: string) =>
+      join(runDir, 'stages', category, 'flavors', flavor, 'artifact-index.jsonl'),
+    flavorArtifactsDir: (category: StageCategory, flavor: string) =>
+      join(runDir, 'stages', category, 'flavors', flavor, 'artifacts'),
+    flavorSynthesis: (category: StageCategory, flavor: string) =>
+      join(runDir, 'stages', category, 'flavors', flavor, 'synthesis.md'),
+    stageSynthesis: (category: StageCategory) =>
+      join(runDir, 'stages', category, 'synthesis.md'),
+  };
+}
+
+/**
+ * Create the full directory tree for a new run.
+ * Creates run directory + per-stage directories + placeholder state files.
+ */
+export function createRunTree(runsDir: string, run: Run): void {
+  const paths = runPaths(runsDir, run.id);
+
+  // Create top-level run directory
+  mkdirSync(paths.runDir, { recursive: true });
+
+  // Write run.json
+  JsonStore.write(paths.runJson, run, RunSchema);
+
+  // Create stage directories + initial state files
+  for (const category of run.stageSequence) {
+    mkdirSync(paths.stageDir(category), { recursive: true });
+
+    const stageState: StageState = {
+      category,
+      status: 'pending',
+      selectedFlavors: [],
+      gaps: [],
+      decisions: [],
+    };
+    JsonStore.write(paths.stateJson(category), stageState, StageStateSchema);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run CRUD
+// ---------------------------------------------------------------------------
+
+export function readRun(runsDir: string, runId: string): Run {
+  return JsonStore.read(runPaths(runsDir, runId).runJson, RunSchema);
+}
+
+export function writeRun(runsDir: string, run: Run): void {
+  JsonStore.write(runPaths(runsDir, run.id).runJson, run, RunSchema);
+}
+
+// ---------------------------------------------------------------------------
+// Stage state CRUD
+// ---------------------------------------------------------------------------
+
+export function readStageState(runsDir: string, runId: string, category: StageCategory): StageState {
+  return JsonStore.read(runPaths(runsDir, runId).stateJson(category), StageStateSchema);
+}
+
+export function writeStageState(runsDir: string, runId: string, state: StageState): void {
+  JsonStore.write(runPaths(runsDir, runId).stateJson(state.category), state, StageStateSchema);
+}
+
+// ---------------------------------------------------------------------------
+// Flavor state CRUD
+// ---------------------------------------------------------------------------
+
+export function readFlavorState(
+  runsDir: string,
+  runId: string,
+  category: StageCategory,
+  flavorName: string,
+): FlavorState {
+  return JsonStore.read(
+    runPaths(runsDir, runId).flavorStateJson(category, flavorName),
+    FlavorStateSchema,
+  );
+}
+
+export function writeFlavorState(
+  runsDir: string,
+  runId: string,
+  category: StageCategory,
+  state: FlavorState,
+): void {
+  const flavorDir = runPaths(runsDir, runId).flavorDir(category, state.name);
+  mkdirSync(flavorDir, { recursive: true });
+  JsonStore.write(
+    runPaths(runsDir, runId).flavorStateJson(category, state.name),
+    state,
+    FlavorStateSchema,
+  );
+}

--- a/src/shared/constants/paths.ts
+++ b/src/shared/constants/paths.ts
@@ -4,6 +4,7 @@ export const KATA_DIRS = {
   flavors: 'flavors',
   pipelines: 'pipelines',
   cycles: 'cycles',
+  runs: 'runs',
   history: 'history',
   knowledge: 'knowledge',
   templates: 'templates',


### PR DESCRIPTION
## Summary

- Implements the `.kata/runs/<run-id>/` file system (run state infrastructure) for v1 orchestration execution
- Adds agent-facing CLI commands for recording decisions, artifacts, and querying run status
- Adds `GapSchema`, `PendingGateSchema`, and `KataAssignmentSchema` — spec-aligned structured types that unblock Session 2

## Closes

Fixes #94, #97, #98, #108, #109

## New files

| File | Purpose |
|------|---------|
| `src/domain/types/run-state.ts` | 9 Zod schemas for the run state file tree |
| `src/infrastructure/persistence/jsonl-store.ts` | Append-only JSONL with schema validation |
| `src/infrastructure/persistence/run-store.ts` | Path helpers + CRUD for run/stage/flavor state |
| `src/cli/commands/artifact.ts` | `kata artifact record` |
| `src/cli/commands/decision.ts` | `kata decision record` + `kata decision update` |
| `src/cli/commands/run.ts` | `kata run status` |

## Test plan

- [ ] `npm test` — 1413 tests pass (up from 1348, 65 new)
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `kata artifact record` copies file, appends to artifact-index.jsonl, updates flavor step
- [ ] `kata decision record` appends to decisions.jsonl, updates stage state decisions array
- [ ] `kata decision update` appends to decision-outcomes.jsonl, validates decision ID exists
- [ ] `kata run status` renders human-readable summary + `--json` payload

## Follow-up issues

- #111 — pre-Session 2 cleanup (7 polish items, prerequisite for Session 2)
- #112 — Wave C: cooldown integration with run data (blocked by #95, #96)
- #113 — Flavor state initialization contract documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)