### PR TITLE
feat: Wave A Session 2 — cycle betting, run creation, gate approval, step-next, confidence gates

### DIFF
--- a/src/cli/commands/approve.test.ts
+++ b/src/cli/commands/approve.test.ts
@@ -1,0 +1,246 @@
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { registerApproveCommand } from './approve.js';
+import { createRunTree, readStageState, writeStageState } from '@infra/persistence/run-store.js';
+import type { Run } from '@domain/types/run-state.js';
+
+// Mock @inquirer/prompts to avoid interactive prompts in tests
+vi.mock('@inquirer/prompts', () => ({
+  checkbox: vi.fn().mockResolvedValue([]),
+}));
+
+function tempBase(): string {
+  return join(tmpdir(), `kata-approve-test-${randomUUID()}`);
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    cycleId: randomUUID(),
+    betId: randomUUID(),
+    betPrompt: 'Implement auth',
+    stageSequence: ['research', 'plan'],
+    currentStage: null,
+    status: 'running',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('registerApproveCommand', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerApproveCommand(program);
+    return program;
+  }
+
+  it('returns empty array when no pending gates exist', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--json', '--cwd', baseDir, 'approve']);
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output).toEqual([]);
+  });
+
+  it('shows "No pending gates." message in non-JSON mode', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', '--cwd', baseDir, 'approve']);
+
+    expect(consoleSpy).toHaveBeenCalledWith('No pending gates.');
+  });
+
+  it('approves a gate by gate-id', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    // Write a pending gate to stage state
+    const stageState = readStageState(runsDir, run.id, 'research');
+    stageState.pendingGate = {
+      gateId: 'gate-abc123',
+      gateType: 'human-approved',
+      requiredBy: 'stage',
+    };
+    writeStageState(runsDir, run.id, stageState);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'approve', 'gate-abc123',
+    ]);
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output).toHaveLength(1);
+    expect(output[0].gateId).toBe('gate-abc123');
+    expect(output[0].gateType).toBe('human-approved');
+    expect(output[0].approver).toBe('human');
+    expect(output[0].runId).toBe(run.id);
+    expect(output[0].stage).toBe('research');
+  });
+
+  it('approves a gate with --agent flag', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const stageState = readStageState(runsDir, run.id, 'research');
+    stageState.pendingGate = {
+      gateId: 'gate-agent-test',
+      gateType: 'confidence-gate',
+      requiredBy: 'research-flavor',
+    };
+    writeStageState(runsDir, run.id, stageState);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'approve', 'gate-agent-test', '--agent',
+    ]);
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output[0].approver).toBe('agent');
+  });
+
+  it('clears pendingGate and moves to approvedGates after approval', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const stageState = readStageState(runsDir, run.id, 'plan');
+    stageState.pendingGate = {
+      gateId: 'gate-plan-001',
+      gateType: 'human-approved',
+      requiredBy: 'stage',
+    };
+    writeStageState(runsDir, run.id, stageState);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'approve', 'gate-plan-001',
+    ]);
+
+    const updatedState = readStageState(runsDir, run.id, 'plan');
+    expect(updatedState.pendingGate).toBeUndefined();
+    expect(updatedState.approvedGates).toHaveLength(1);
+    expect(updatedState.approvedGates[0]!.gateId).toBe('gate-plan-001');
+  });
+
+  it('errors when gate ID is not found', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'approve', 'nonexistent-gate',
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"nonexistent-gate" not found'));
+  });
+
+  it('scopes gate search to --run when provided', async () => {
+    const run1 = makeRun();
+    const run2 = makeRun();
+    createRunTree(runsDir, run1);
+    createRunTree(runsDir, run2);
+
+    // Gate on run2
+    const stageState = readStageState(runsDir, run2.id, 'research');
+    stageState.pendingGate = {
+      gateId: 'gate-run2-only',
+      gateType: 'human-approved',
+      requiredBy: 'stage',
+    };
+    writeStageState(runsDir, run2.id, stageState);
+
+    // Approve scoped to run1 — should not find the gate on run2
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'approve', 'gate-run2-only', '--run', run1.id,
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('skips gracefully when gate is already cleared (race condition)', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    // Set gate so findPendingGates picks it up
+    const stageState = readStageState(runsDir, run.id, 'research');
+    stageState.pendingGate = {
+      gateId: 'gate-race',
+      gateType: 'human-approved',
+      requiredBy: 'stage',
+    };
+    writeStageState(runsDir, run.id, stageState);
+
+    // Simulate race: clear the gate before the approve loop reads it
+    const clearedState = readStageState(runsDir, run.id, 'research');
+    clearedState.pendingGate = undefined;
+    writeStageState(runsDir, run.id, clearedState);
+
+    // Approve by gate-id — gate is now gone, should report no gates approved
+    const program = createProgram();
+    // findPendingGates scans from disk — gate is already cleared, so it won't find it
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'approve', 'gate-race',
+    ]);
+
+    // Gate not found error because pendingGate was already cleared
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('handles no runs directory without error (returns no pending gates)', async () => {
+    // Use a fresh kataDir with no runs/ directory
+    const freshBase = join(tmpdir(), `kata-approve-fresh-${randomUUID()}`);
+    const freshKataDir = join(freshBase, '.kata');
+    mkdirSync(freshKataDir, { recursive: true });
+
+    const consoleSpy2 = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--json', '--cwd', freshBase, 'approve']);
+
+      const output = JSON.parse(consoleSpy2.mock.calls[0]![0] as string);
+      expect(output).toEqual([]);
+    } finally {
+      consoleSpy2.mockRestore();
+      rmSync(freshBase, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/commands/approve.ts
+++ b/src/cli/commands/approve.ts
@@ -1,0 +1,173 @@
+import { readdirSync } from 'node:fs';
+import type { Command } from 'commander';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+import {
+  readRun,
+  readStageState,
+  writeStageState,
+} from '@infra/persistence/run-store.js';
+import { ApprovedGateSchema } from '@domain/types/run-state.js';
+import type { PendingGate } from '@domain/types/run-state.js';
+import type { StageCategory } from '@domain/types/stage.js';
+
+interface PendingGateEntry {
+  runId: string;
+  stage: StageCategory;
+  gate: PendingGate;
+}
+
+/**
+ * Scan all run directories for pending gates.
+ * Optionally scoped to a single runId.
+ */
+function findPendingGates(runsDir: string, scopeRunId?: string): PendingGateEntry[] {
+  let runIds: string[];
+
+  if (scopeRunId) {
+    runIds = [scopeRunId];
+  } else {
+    let entries: string[];
+    try {
+      entries = readdirSync(runsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+    } catch (err) {
+      // Runs directory doesn't exist yet — no pending gates
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+    runIds = entries;
+  }
+
+  const pending: PendingGateEntry[] = [];
+
+  for (const runId of runIds) {
+    let run;
+    try {
+      run = readRun(runsDir, runId);
+    } catch {
+      // Not a valid run directory
+      continue;
+    }
+
+    for (const stage of run.stageSequence) {
+      let stageState;
+      try {
+        stageState = readStageState(runsDir, runId, stage);
+      } catch {
+        continue;
+      }
+
+      if (stageState.pendingGate) {
+        pending.push({ runId, stage, gate: stageState.pendingGate });
+      }
+    }
+  }
+
+  return pending;
+}
+
+export function registerApproveCommand(parent: Command): void {
+  parent
+    .command('approve [gate-id]')
+    .description('Approve a pending gate (human or agent approval)')
+    .option('--run <run-id>', 'Scope to a specific run')
+    .option('--agent', 'Approve as agent (default: human)')
+    .action(withCommandContext(async (ctx, gateId: string | undefined) => {
+      const localOpts = ctx.cmd.opts();
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+      const approver: 'human' | 'agent' = localOpts.agent ? 'agent' : 'human';
+
+      const allPending = findPendingGates(runsDir, localOpts.run as string | undefined);
+
+      let toApprove: PendingGateEntry[];
+
+      if (gateId) {
+        // Find by specific gate ID
+        toApprove = allPending.filter((e) => e.gate.gateId === gateId);
+        if (toApprove.length === 0) {
+          const scope = localOpts.run ? ` in run "${localOpts.run as string}"` : '';
+          throw new Error(`Gate "${gateId}" not found${scope} or is not in pending state.`);
+        }
+      } else if (allPending.length === 0) {
+        if (ctx.globalOpts.json) {
+          console.log(JSON.stringify([], null, 2));
+        } else {
+          console.log('No pending gates.');
+        }
+        return;
+      } else {
+        // Interactive selection
+        const { checkbox } = await import('@inquirer/prompts');
+        const choices = allPending.map((e) => ({
+          name: `[${e.runId.slice(0, 8)}] ${e.stage} — ${e.gate.gateType} (${e.gate.gateId})`,
+          value: e,
+          checked: true,
+        }));
+
+        toApprove = await checkbox({
+          message: 'Select gates to approve:',
+          choices,
+        }) as PendingGateEntry[];
+
+        if (toApprove.length === 0) {
+          console.log('No gates selected.');
+          return;
+        }
+      }
+
+      const now = new Date().toISOString();
+      const approved: Array<{
+        gateId: string;
+        gateType: string;
+        approvedAt: string;
+        approver: 'human' | 'agent';
+        runId: string;
+        stage: StageCategory;
+      }> = [];
+
+      for (const entry of toApprove) {
+        const stageState = readStageState(runsDir, entry.runId, entry.stage);
+
+        if (!stageState.pendingGate || stageState.pendingGate.gateId !== entry.gate.gateId) {
+          // Gate was already cleared (race condition or stale data)
+          continue;
+        }
+
+        const approvedGate = ApprovedGateSchema.parse({
+          gateId: entry.gate.gateId,
+          gateType: entry.gate.gateType,
+          requiredBy: entry.gate.requiredBy,
+          approvedAt: now,
+          approver,
+        });
+
+        stageState.approvedGates.push(approvedGate);
+        stageState.pendingGate = undefined;
+
+        writeStageState(runsDir, entry.runId, stageState);
+
+        approved.push({
+          gateId: entry.gate.gateId,
+          gateType: entry.gate.gateType,
+          approvedAt: now,
+          approver,
+          runId: entry.runId,
+          stage: entry.stage,
+        });
+      }
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify(approved, null, 2));
+      } else {
+        if (approved.length === 0) {
+          console.log('No gates were approved (already cleared).');
+        } else {
+          for (const g of approved) {
+            console.log(`✓ Approved gate "${g.gateId}" (${g.gateType}) in run ${g.runId.slice(0, 8)} stage "${g.stage}" as ${g.approver}`);
+          }
+        }
+      }
+    }));
+}
+

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -120,7 +120,8 @@ export function registerArtifactCommands(parent: Command): void {
 
       // Update flavor state.json step artifacts if applicable
       if (artifactType === 'artifact' && existsSync(flavorStateFile)) {
-        const flavorState = readFlavorState(runsDir, runId, stage, localOpts.flavor as string);
+        // existsSync guard ensures the file exists, so non-null assertion is safe
+        const flavorState = readFlavorState(runsDir, runId, stage, localOpts.flavor as string)!;
         const stepName = localOpts.step as string; // non-null validated above
         const stepIndex = flavorState.steps.findIndex((s) => s.type === stepName);
 

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -14,7 +14,6 @@ import {
   DecisionOutcomeEntrySchema,
   type Gap,
   type StageState,
-  type FlavorState,
   type Run,
   type DecisionEntry,
   type DecisionOutcomeEntry,
@@ -86,6 +85,7 @@ function aggregateRunStatus(runsDir: string, runId: string): RunStatus {
         selectedFlavors: [],
         gaps: [],
         decisions: [],
+        approvedGates: [],
       };
     }
 
@@ -100,12 +100,7 @@ function aggregateRunStatus(runsDir: string, runId: string): RunStatus {
     // Collect flavor summaries
     const flavors: FlavorSummary[] = [];
     for (const flavorName of stageState.selectedFlavors) {
-      let flavorState: FlavorState | undefined;
-      try {
-        flavorState = readFlavorState(runsDir, runId, category, flavorName);
-      } catch {
-        // Flavor state not initialized yet
-      }
+      const flavorState = readFlavorState(runsDir, runId, category, flavorName, { allowMissing: true });
 
       const flavorArtifacts = stageArtifacts.filter((a) => a.flavor === flavorName);
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -11,6 +11,7 @@ import { registerStatusCommands } from './commands/status.js';
 import { registerArtifactCommands } from './commands/artifact.js';
 import { registerDecisionCommands } from './commands/decision.js';
 import { registerRunCommands } from './commands/run.js';
+import { registerApproveCommand } from './commands/approve.js';
 
 const VERSION = '0.1.0';
 
@@ -45,6 +46,7 @@ export function createProgram(): Command {
   registerArtifactCommands(program);
   registerDecisionCommands(program);
   registerRunCommands(program);
+  registerApproveCommand(program);
 
   return program;
 }

--- a/src/domain/types/config.ts
+++ b/src/domain/types/config.ts
@@ -15,7 +15,13 @@ export const KataConfigSchema = z.object({
   execution: z.object({
     adapter: ExecutionAdapterType.default('manual'),
     config: z.record(z.string(), z.unknown()).default({}),
-  }).default(() => ({ adapter: 'manual' as const, config: {} })),
+    /**
+     * Minimum confidence score [0, 1] before a decision triggers a gate.
+     * Decisions below this threshold require human approval (or --yolo to skip).
+     * Defaults to 0.7.
+     */
+    confidenceThreshold: z.number().min(0).max(1).default(0.7),
+  }).default(() => ({ adapter: 'manual' as const, config: {}, confidenceThreshold: 0.7 })),
   /** Custom stage paths to load */
   customStagePaths: z.array(z.string()).default([]),
   /** Project metadata */


### PR DESCRIPTION
## Issues closed
- #95 `kata cycle add-bet` / `update-bet` — assign named or ad-hoc kata to bets; `CycleManager.updateBet()` + `findBetCycle()`
- #96 `kata cycle start` — validates kata assignments, creates run trees per bet, transitions cycle to active
- #99 `kata approve [gate-id]` — approve pending gates (human/agent), interactive checkbox selector, `ApprovedGateSchema`
- #100 `kata step next <run-id>` — queries next step with full context: prompt, gates, prior artifacts, prior stage syntheses
- #101 `kata decision record --yolo` — confidence gate creation below threshold, bypass with `--yolo`, `confidenceThreshold` in config
- #113 `createRunTree` JSDoc; `readFlavorState` `allowMissing` option

## Review fixes (code-reviewer + silent-failure-hunter + test-analyzer)
- `approve.ts`: ENOENT-only catch on `readdirSync` — permission errors now propagate instead of silently returning no gates
- `decision.ts`: separated `readStageState` failure (non-fatal) from `writeStageState` failure (now fatal — gate must persist); `lowConfidence: true` set on all below-threshold decisions for retrospective log analysis
- `cycle.ts start`: pre-flight loads all named kata files before `startCycle()` — cycle stays in `planning` state if any kata file is missing
- `step.ts next`: removed fallback default `stageState`; read errors propagate instead of silently bypassing pending gates
- `cycle.ts`: `kataDirPath(ctx.kataDir, 'katas')` instead of bare `join`

## Test plan
- [x] 1478 tests passing (81 test files), up from 1413
- [x] `npm run typecheck` — clean
- [x] New tests: confidence threshold boundary (`<` not `<=`), multi-bet cycle start (2 runs), `step next` with `currentStage` + `priorStageSyntheses`, approve race condition, `lowConfidence` field on gate-path decisions, second-gate guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `approve` command to approve pending gates
  * Added cycle management commands: `add-bet`, `update-bet`, and `start`
  * Added `step next` command to determine the next executable step for a run
  * Added `--yolo` flag to bypass low-confidence decision gates
  * Added configurable confidence threshold for decision gating

<!-- end of auto-generated comment: release notes by coderabbit.ai -->