### PR TITLE
fix: cli-reference.md --json flag placement and example consistency

### DIFF
--- a/skill/cli-reference.md
+++ b/skill/cli-reference.md
@@ -1,7 +1,8 @@
 # Kata CLI Reference — Agent-Facing Commands
 
 > All commands support `--json` for machine-readable output.
-> Global flag `--json` must precede the subcommand: `kata --json run status <id>`.
+> `--json` is a global flag — append it anywhere in the command: `kata run status <id> --json`
+> The program does not use positional option parsing, so placement does not matter.
 
 ---
 
@@ -20,7 +21,7 @@ Add a bet to a cycle in `planning` state, with an optional kata assignment.
 ```bash
 kata cycle add-bet "$CYCLE_ID" "Implement OAuth2 login flow" \
   --kata full-feature \
-  --appetite 30
+  --appetite 30 --json
 ```
 
 **`--json` output**:
@@ -79,8 +80,8 @@ Update the kata assignment for an existing bet (before the cycle starts).
 
 **Example**:
 ```bash
-kata cycle update-bet "$BET_ID" --kata full-feature
-kata cycle update-bet "$BET_ID" --gyo "research,build"
+kata cycle update-bet "$BET_ID" --kata full-feature --json
+kata cycle update-bet "$BET_ID" --gyo "research,build" --json
 ```
 
 **`--json` output**: Same shape as `kata cycle add-bet --json` (full `{ status, cycle }` object).
@@ -295,7 +296,7 @@ kata artifact record "$RUN_ID" \
   --flavor rust-compilation \
   --step compile \
   --file /tmp/build-report.md \
-  --summary "Cargo build output: 0 errors, 2 warnings"
+  --summary "Cargo build output: 0 errors, 2 warnings" --json
 ```
 
 **`--json` output**:
@@ -343,7 +344,7 @@ kata decision record "$RUN_ID" \
   --options '["web-standards","internal-docs"]' \
   --selected web-standards \
   --confidence 0.9 \
-  --reasoning "Bet mentions OAuth2 specifically; web-standards covers the RFC"
+  --reasoning "Bet mentions OAuth2 specifically; web-standards covers the RFC" --json
 ```
 
 **`--json` output**:
@@ -393,8 +394,8 @@ Approve a pending gate.
 
 **Example**:
 ```bash
-kata approve confidence-3b07e7d4
-kata approve --run "$RUN_ID"    # approve all pending in a run
+kata approve confidence-3b07e7d4 --json
+kata approve --run "$RUN_ID" --json    # approve all pending in a run
 ```
 
 **`--json` output** (array of approved gates):
@@ -430,7 +431,7 @@ Record a post-facto outcome for a decision (used during cooldown or after observ
 ```bash
 kata decision update "$RUN_ID" "$DECISION_ID" \
   --outcome good \
-  --notes "web-standards research uncovered the critical token expiry constraint"
+  --notes "web-standards research uncovered the critical token expiry constraint" --json
 ```
 
 **`--json` output**:


### PR DESCRIPTION
## Summary

- Corrects the header note: `--json` is a global flag that can appear **anywhere** in the command line — the old note said "must precede the subcommand" (`kata --json run status <id>`), which was wrong. The kata program does not call `enablePositionalOptions()`, so Commander.js accepts `--json` at any position.
- Adds `--json` to all command examples so agents can copy-paste and immediately get machine-readable output without guessing where the flag goes.

## Changes

One file: `skill/cli-reference.md`

| Change | Detail |
|--------|--------|
| Header note | "must precede the subcommand" → "append it anywhere" |
| `kata cycle add-bet` example | Added `--json` |
| `kata cycle update-bet` examples | Added `--json` |
| `kata artifact record` example | Added `--json` |
| `kata decision record` example | Added `--json` |
| `kata approve` examples | Added `--json` |
| `kata decision update` example | Added `--json` |

## Test plan

- [ ] No source code changes — existing 1484 tests pass
- [ ] Verify that `kata run status <id> --json` works (flag at end) — confirms no positional parsing

Identified during PR #124 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the --json flag is a global option that can be placed anywhere in commands, providing greater flexibility in command syntax.
  * Updated command examples to demonstrate flag placement at the end of commands.
  * Enhanced guidance on consistent --json output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->