### PR TITLE
fix(#123): resolve prompt template path relative to stagesDir not kataDir

### DIFF
--- a/src/cli/commands/step.ts
+++ b/src/cli/commands/step.ts
@@ -169,7 +169,7 @@ export function registerStepCommands(parent: Command): void {
       // Resolve prompt
       let prompt = stepDef?.description ?? '';
       if (stepDef?.promptTemplate) {
-        const promptPath = resolve(ctx.kataDir, stepDef.promptTemplate);
+        const promptPath = resolve(stagesDir, stepDef.promptTemplate);
         if (existsSync(promptPath)) {
           const raw = readFileSync(promptPath, 'utf-8');
           prompt = raw.replace(/\{\{\s*betPrompt\s*\}\}/g, run.betPrompt);


### PR DESCRIPTION
## Summary

- **Bug**: `kata step next` resolved `promptTemplate` paths (e.g. `../prompts/shape.md`) relative to `.kata/` (kataDir), producing `<project-root>/prompts/shape.md` instead of `.kata/prompts/shape.md`
- **Fix**: one-line change in `step.ts:172` — `resolve(ctx.kataDir, ...)` → `resolve(stagesDir, ...)`
- **Test**: new regression test writes a prompt file at `.kata/prompts/research.md` and asserts the interpolated content (not the fallback description) appears in `step next` JSON output

## Root cause

Step definitions store `promptTemplate: "../prompts/shape.md"` — a path relative to `.kata/stages/`. The resolve base must be `stagesDir`, not `kataDir`.

| Base | Resolution | Correct? |
|------|-----------|---------|
| `kataDir` (`.kata/`) | `.../prompts/shape.md` (project root) | ❌ |
| `stagesDir` (`.kata/stages/`) | `.kata/stages/../prompts/shape.md` → `.kata/prompts/shape.md` | ✅ |

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)