### PR TITLE
feat: kata step complete, kata stage complete, kata gate set (#120 #121 #122)

### DIFF
--- a/skill/skill.md
+++ b/skill/skill.md
@@ -92,8 +92,10 @@ Returns full run state: all stages, flavors, steps, decisions, and artifacts.
 | Record artifacts | `kata artifact record` — always use CLI for writes |
 | Record decisions | `kata decision record` — always use CLI for writes |
 | Approve gates | `kata approve` — always use CLI |
+| Set a gate | `kata gate set` — always use CLI |
 | Get next step | `kata step next` — returns what to work on next |
-| **Advance** step state | Write `FlavorState` JSON directly — no CLI exists yet (see section 7) |
+| Mark step complete | `kata step complete` — always use CLI |
+| Mark stage complete + advance | `kata stage complete` — always use CLI |
 | **Read** run state | Read `.kata/runs/<run-id>/run.json` directly |
 | **Read** stage state | Read `.kata/runs/<run-id>/stages/<category>/state.json` directly |
 | **Read** artifact files | Browse `.kata/runs/<run-id>/stages/<category>/flavors/<name>/artifacts/` directly |
@@ -157,19 +159,21 @@ Use `--yolo` for decisions where pausing would be more disruptive than the risk 
 
 ---
 
-## 7. Known CLI Limitations (v1 Wave B)
+## 7. Known CLI Limitations (v1 Wave C)
 
-The following operations require **direct file writes** because CLI commands don't exist yet. See `orchestration.md` for exact JSON shapes.
+The following operations require **direct file writes** because CLI commands don't exist yet.
 
 | Operation | Workaround |
 |-----------|-----------|
-| Mark a step as completed | Write `FlavorState` JSON to `.kata/runs/<id>/stages/<cat>/flavors/<step-type>/state.json` |
 | Set `selectedFlavors` for a stage | Write directly to `.kata/runs/<id>/stages/<cat>/state.json` |
-| Advance to next stage | Update `currentStage` in `.kata/runs/<id>/run.json` |
-| Mark a stage as completed | Update `status` in stage `state.json` |
-| Set a human-approval gate | Write `pendingGate` to stage `state.json` |
 | Mark run completed | Set `status: "completed"` and `completedAt` in `run.json` |
 
-**Flavor name ≠ step types**: Flavor composition files (`.kata/flavors/plan.api-design.json`) define multi-step sequences. You record decisions using the **flavor name**, but you write **step types** to `selectedFlavors`. Read the flavor JSON to extract step types (`steps[].stepType`).
+The following operations now have CLI commands (Wave C):
 
-These gaps are tracked as issues and will be resolved in Wave C (orchestration engine).
+| Operation | CLI command |
+|-----------|------------|
+| Mark a step as completed | `kata step complete <run-id> --stage <cat> --flavor <name> --step <type>` |
+| Mark a stage as completed + advance run | `kata stage complete <run-id> --stage <cat> [--synthesis <file>]` |
+| Set a human-approval gate | `kata gate set <run-id> --stage <cat> --gate-id <id> [--type <type>]` |
+
+**Flavor name ≠ step types**: Flavor composition files (`.kata/flavors/plan.api-design.json`) define multi-step sequences. You record decisions using the **flavor name**, but you write **step types** to `selectedFlavors`. Read the flavor JSON to extract step types (`steps[].stepType`).

--- a/src/cli/commands/gate.test.ts
+++ b/src/cli/commands/gate.test.ts
@@ -1,0 +1,262 @@
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { registerGateCommands } from './gate.js';
+import {
+  createRunTree,
+  readStageState,
+  writeStageState,
+} from '@infra/persistence/run-store.js';
+import type { Run } from '@domain/types/run-state.js';
+
+function tempBase(): string {
+  return join(tmpdir(), `kata-gate-test-${randomUUID()}`);
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: randomUUID(),
+    cycleId: randomUUID(),
+    betId: randomUUID(),
+    betPrompt: 'Build feature',
+    stageSequence: ['plan', 'build'],
+    currentStage: 'plan',
+    status: 'running',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('registerGateCommands', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let runsDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = tempBase();
+    kataDir = join(baseDir, '.kata');
+    runsDir = join(kataDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerGateCommands(program);
+    return program;
+  }
+
+  describe('gate set', () => {
+    it('sets a pending gate on a running stage', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      // Stage must be running
+      const stageState = readStageState(runsDir, run.id, 'plan');
+      stageState.status = 'running';
+      writeStageState(runsDir, run.id, stageState);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--json', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'gate-plan-review',
+      ]);
+
+      const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+      expect(output.gateId).toBe('gate-plan-review');
+      expect(output.gateType).toBe('human-approved');
+      expect(output.stage).toBe('plan');
+      expect(output.runId).toBe(run.id);
+
+      const updatedState = readStageState(runsDir, run.id, 'plan');
+      expect(updatedState.pendingGate?.gateId).toBe('gate-plan-review');
+      expect(updatedState.pendingGate?.gateType).toBe('human-approved');
+      expect(updatedState.pendingGate?.requiredBy).toBe('stage');
+    });
+
+    it('uses custom gate type when --type provided', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      const stageState = readStageState(runsDir, run.id, 'plan');
+      stageState.status = 'running';
+      writeStageState(runsDir, run.id, stageState);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--json', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'my-gate', '--type', 'confidence-gate',
+      ]);
+
+      const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+      expect(output.gateType).toBe('confidence-gate');
+
+      const updatedState = readStageState(runsDir, run.id, 'plan');
+      expect(updatedState.pendingGate?.gateType).toBe('confidence-gate');
+    });
+
+    it('prints non-JSON message with approval hint', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      const stageState = readStageState(runsDir, run.id, 'plan');
+      stageState.status = 'running';
+      writeStageState(runsDir, run.id, stageState);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'gate-abc',
+      ]);
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('gate-abc'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('kata approve gate-abc'));
+    });
+
+    it('errors when stage is not running (pending)', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+      // Stage is 'pending' by default after createRunTree
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'gate-fail',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not running'));
+    });
+
+    it('errors when a pending gate is already set', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      const stageState = readStageState(runsDir, run.id, 'plan');
+      stageState.status = 'running';
+      stageState.pendingGate = {
+        gateId: 'existing-gate',
+        gateType: 'human-approved',
+        requiredBy: 'stage',
+      };
+      writeStageState(runsDir, run.id, stageState);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'new-gate',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('existing-gate'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('kata approve'));
+    });
+
+    it('warns but allows setting a gate already in approvedGates', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      const stageState = readStageState(runsDir, run.id, 'plan');
+      stageState.status = 'running';
+      stageState.approvedGates = [{
+        gateId: 'already-approved',
+        gateType: 'human-approved',
+        requiredBy: 'stage',
+        approvedAt: '2026-01-01T00:00:00.000Z',
+        approver: 'human',
+      }];
+      writeStageState(runsDir, run.id, stageState);
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'plan', '--gate-id', 'already-approved',
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already approved'));
+      warnSpy.mockRestore();
+
+      // Gate should still be set
+      const updatedState = readStageState(runsDir, run.id, 'plan');
+      expect(updatedState.pendingGate?.gateId).toBe('already-approved');
+    });
+
+    it('errors on invalid stage category', async () => {
+      const run = makeRun();
+      createRunTree(runsDir, run);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'invalid', '--gate-id', 'gate-x',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid stage category'));
+    });
+
+    it('errors when stage is not initialized', async () => {
+      const run = makeRun({ stageSequence: ['plan', 'build'] });
+      createRunTree(runsDir, run);
+
+      // Manually remove the build state.json to simulate uninitialized state
+      const { rmSync: rmS } = await import('node:fs');
+      const buildStatePath = join(runsDir, run.id, 'stages', 'build', 'state.json');
+      rmS(buildStatePath, { force: true });
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'build', '--gate-id', 'gate-x',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not initialized'));
+    });
+
+    it('errors when stage is not in the run stageSequence', async () => {
+      const run = makeRun({ stageSequence: ['plan'] });
+      createRunTree(runsDir, run);
+
+      // 'research' is a valid category but not in this run's sequence
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', run.id,
+        '--stage', 'research', '--gate-id', 'gate-x',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not in the sequence'));
+    });
+
+    it('errors when run does not exist', async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'gate', 'set', randomUUID(),
+        '--stage', 'plan', '--gate-id', 'gate-x',
+      ]);
+
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cli/commands/gate.ts
+++ b/src/cli/commands/gate.ts
@@ -1,0 +1,90 @@
+import type { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+import {
+  readRun,
+  readStageState,
+  writeStageState,
+  runPaths,
+} from '@infra/persistence/run-store.js';
+import { StageCategorySchema } from '@domain/types/stage.js';
+import { PendingGateSchema } from '@domain/types/run-state.js';
+
+export function registerGateCommands(parent: Command): void {
+  const gate = parent
+    .command('gate')
+    .description('Manage run gates');
+
+  // ---- set <run-id> ----
+  gate
+    .command('set <run-id>')
+    .description('Set a pending gate on a running stage, blocking execution until approved')
+    .requiredOption('--stage <category>', 'Stage category (research, plan, build, review)')
+    .requiredOption('--gate-id <id>', 'Gate identifier used with "kata approve <gate-id>"')
+    .option('--type <gate-type>', 'Gate type descriptor', 'human-approved')
+    .action(withCommandContext(async (ctx, runId: string) => {
+      const localOpts = ctx.cmd.opts();
+      const runsDir = kataDirPath(ctx.kataDir, 'runs');
+
+      const stageResult = StageCategorySchema.safeParse(localOpts.stage);
+      if (!stageResult.success) {
+        throw new Error(`Invalid stage category: "${localOpts.stage}". Valid: ${StageCategorySchema.options.join(', ')}`);
+      }
+      const stage = stageResult.data;
+      const gateId = localOpts.gateId as string;
+      const gateType = localOpts.type as string;
+
+      // Verify run exists and stage is part of its sequence
+      const run = readRun(runsDir, runId);
+      if (!run.stageSequence.includes(stage)) {
+        throw new Error(
+          `Stage "${stage}" is not in the sequence for run "${runId}". Sequence: ${run.stageSequence.join(', ')}.`
+        );
+      }
+
+      // Check that the stage directory was initialized before reading
+      // (avoids masking real I/O errors with a misleading "not initialized" message)
+      const statePath = runPaths(runsDir, runId).stateJson(stage);
+      if (!existsSync(statePath)) {
+        throw new Error(`Stage "${stage}" is not initialized for run "${runId}".`);
+      }
+      const stageState = readStageState(runsDir, runId, stage);
+
+      // Stage must be running
+      if (stageState.status !== 'running') {
+        throw new Error(
+          `Stage "${stage}" is not running (current status: "${stageState.status}"). Only running stages can have gates set.`
+        );
+      }
+
+      // Pending gate already set
+      if (stageState.pendingGate) {
+        throw new Error(
+          `Stage "${stage}" already has a pending gate "${stageState.pendingGate.gateId}". Run "kata approve ${stageState.pendingGate.gateId}" first.`
+        );
+      }
+
+      // Warn if gate was already approved (allow but warn)
+      const alreadyApproved = stageState.approvedGates.some((g) => g.gateId === gateId);
+      if (alreadyApproved && !ctx.globalOpts.json) {
+        console.warn(`Warning: gate "${gateId}" was already approved for this stage. Setting it again.`);
+      }
+
+      const pendingGate = PendingGateSchema.parse({
+        gateId,
+        gateType,
+        requiredBy: 'stage',
+      });
+
+      stageState.pendingGate = pendingGate;
+      writeStageState(runsDir, runId, stageState);
+
+      const result = { gateId, gateType, stage, runId };
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Gate "${gateId}" (${gateType}) set on stage "${stage}" in run ${runId.slice(0, 8)}.`);
+        console.log(`Run "kata approve ${gateId}" to unblock.`);
+      }
+    }));
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -12,6 +12,7 @@ import { registerArtifactCommands } from './commands/artifact.js';
 import { registerDecisionCommands } from './commands/decision.js';
 import { registerRunCommands } from './commands/run.js';
 import { registerApproveCommand } from './commands/approve.js';
+import { registerGateCommands } from './commands/gate.js';
 
 const VERSION = '0.1.0';
 
@@ -47,6 +48,7 @@ export function createProgram(): Command {
   registerDecisionCommands(program);
   registerRunCommands(program);
   registerApproveCommand(program);
+  registerGateCommands(program);
 
   return program;
 }


### PR DESCRIPTION
## Summary

Implements the three CLI commands identified as structural gaps during Wave B POC execution (issue #117), eliminating all `node -e` workarounds from `skill/orchestration.md`.

- **`kata step complete <run-id>`** — marks a step completed in `FlavorState`; auto-completes flavor when all steps are done; idempotent
- **`kata stage complete <run-id>`** — copies synthesis file, marks stage completed, advances `run.currentStage` or sets `run.status=completed` on the last stage
- **`kata gate set <run-id>`** — writes `pendingGate` to stage `state.json`; validates stage is in `run.stageSequence` before any mutation

## Bug Fixes (caught in review)

- **`stage complete`**: `indexOf(-1)` would silently corrupt `run.currentStage` to the first stage — guard added before any state mutation
- **`gate set`**: broad `try/catch` masked real I/O errors (EACCES, corrupt JSON, schema failures) as `"not initialized"` — replaced with `existsSync` check + stageSequence validation
- **`step complete`**: already-completed path fell through to spurious `writeFlavorState` and produced no output in `--json` mode — early `return` added with consistent JSON response

## Test plan

- [ ] 26 new tests, 1511 total across 82 files — all passing
- [ ] Happy paths: step complete, stage complete (mid-run and last-stage), gate set
- [ ] Idempotency: step already completed returns status without re-writing
- [ ] Error cases: run-not-found, stage-not-in-sequence, missing synthesis file, stage-not-running, pending-gate-already-set
- [ ] Docs: `skill/cli-reference.md` documents all three commands; `skill/orchestration.md` node -e workarounds removed; `skill/skill.md` section 7 updated

Closes #120, #121, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new CLI commands: `kata step complete` to mark steps as finished, `kata stage complete` to advance stages, and `kata gate set` to manage approval gates. These commands streamline run progression and replace previous manual file-editing workflows.

* **Documentation**
  * Updated CLI reference with complete command specifications including flags, examples, and outputs. Updated orchestration guides to reflect the new command-based workflow for advancing steps and stages.

* **Tests**
  * Added comprehensive test coverage for the new step, stage, and gate commands including error handling and state persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->