### PR TITLE
feat(#103 #104 #49): wire orchestration intelligence phases — rule effects, gap analysis, reflect suggestions

### DIFF
--- a/docs/workspace/20260225-wave-c-s1/breadboard.md
+++ b/docs/workspace/20260225-wave-c-s1/breadboard.md
@@ -1,0 +1,284 @@
+---
+breadboard: true
+pipeline: 20260225-wave-c-s1
+issues: "#103, #104, #49"
+---
+
+# Wave C Session 1 — Breadboard
+
+> **Code-only system.** No UI screens. "Places" are the orchestration phases in
+> `BaseStageOrchestrator`. The "UI Affordances" table captures observable contracts
+> (return types, persisted state) that callers and tests depend on. Code affordances
+> are method-level mechanisms.
+
+---
+
+## Places
+
+| #  | Place                    | Description                                                              |
+| -- | ------------------------ | ------------------------------------------------------------------------ |
+| P0 | `orchestrator.run()`     | Entry coordinator — sequences all 6 phases (unchanged except gap wiring) |
+| P1 | match phase              | `match(stage, context)` — now rule-augmented; evaluates conditions, applies effects |
+| P2 | planExecution phase      | `planExecution(matchResult, context)` — now gap-augmented; detects coverage gaps |
+| P3 | reflect phase            | `reflect(decisions, flavorResults)` — now suggestion-generating; wires outcomes to rule registry |
+| P4 | RuleRegistry             | Persistent store: active `StageRule[]` and pending `RuleSuggestion[]` |
+| P5 | DecisionRegistry         | In-memory + disk store: all `Decision[]` recorded this run |
+
+---
+
+## Public Contracts (Observable Outputs)
+
+What changes from outside the orchestrator. These drive the acceptance criteria and tests.
+
+| #  | Place | Component                   | Affordance                                                        | Control | Wires Out | Returns To  |
+| -- | ----- | --------------------------- | ----------------------------------------------------------------- | ------- | --------- | ----------- |
+| U1 | P1    | `MatchReport`               | `ruleAdjustments` field is non-zero when rules fire; `reasoning` annotated with rule info | return | — | → P2 (planExecution receives matchReports) |
+| U2 | P2    | `OrchestratorResult.gaps`   | `gaps?: GapReport[]` — NEW field on the result (schema change)    | return  | — | → test assertions, kata status display |
+| U3 | P3    | `ReflectionResult.ruleSuggestions` | `ruleSuggestions` now populated with suggestion IDs (was empty array) | return | → P4 | → test assertions |
+| U4 | P4    | `RuleSuggestion` on disk    | Suggestion persisted to `.kata/rules/suggestions/<id>.json`       | write   | — | → (future `kata knowledge rules --pending`) |
+
+---
+
+## Code Affordances
+
+### P1 — match phase (rule wiring, #103)
+
+New private methods added to `BaseStageOrchestrator`:
+
+| #  | Place | Component                  | Affordance                                              | Control | Wires Out | Returns To     |
+| -- | ----- | -------------------------- | ------------------------------------------------------- | ------- | --------- | -------------- |
+| N1 | P1    | BaseStageOrchestrator      | `evaluateRuleCondition(rule, betText, artifacts, category): boolean` — strips stop words from `rule.condition`; returns true if any word appears in betText \| stageCategory \| artifact names | call | — | → N2 |
+| N2 | P1    | BaseStageOrchestrator      | `classifyRuleEffects(rules, capProfile): ClassifiedRules` — iterates rules, calls N1 for each; builds `{excluded: Set<string>, required: Set<string>, adjustments: Map<flavorName, number>}` where adjustments = `±magnitude * confidence` per boost/penalize rule | call | → N1 | → N3 |
+| N3 | P1    | BaseStageOrchestrator      | `match(stage, context)` [**MODIFIED**] — after building excluded/pinned from stage config: calls N2, merges `excluded` into excluded Set (rule excludes win), merges `required` into pinned Set (only if not in excluded); applies `adjustments` to candidate scores; annotates MatchReport.reasoning | call | → S1 (reads rules), → N2 | → U1, → N6 |
+
+**Rule precedence in N3:**
+1. Load `excluded` from `stage.excludedFlavors` + rule-based excludes from N2
+2. Load `pinned` from `stage.pinnedFlavors` + rule-based requires from N2 (exclude wins over require)
+3. For candidates: `score = clamp(base + N2.adjustments.get(flavor.name) ?? 0, 0, 1)`
+
+**Convention documented (not a schema change):** `StageRule.name` = flavor name being targeted; `StageRule.condition` = context description for matching.
+
+---
+
+### P2 — planExecution phase (gap analysis, #104)
+
+New private method + type extension:
+
+| #  | Place | Component                  | Affordance                                              | Control | Wires Out | Returns To      |
+| -- | ----- | -------------------------- | ------------------------------------------------------- | ------- | --------- | --------------- |
+| N4 | P2    | BaseStageOrchestrator      | `detectGaps(selectedFlavors, context): GapReport[]` — for each vocabulary keyword (`this.vocabulary?.keywords`): if it appears in `betText(context)` AND no selected flavor's name/description contains it → gap. Finds `suggestedFlavors` from available unselected flavors that mention the keyword. Severity: high for first-third of keywords, medium for second-third, low for rest | call | — | → N5 |
+| N5 | P2    | DecisionRegistry           | `decisionRegistry.record(gap-assessment decision)` — records decision with type `'gap-assessment'`, context `{gapCount, gaps, selectedFlavors}`, options `['gaps-found','no-gaps']`, selection based on count | call | → S2 | → N6 |
+| N6 | P2    | BaseStageOrchestrator      | `planExecution(matchResult, context)` [**MODIFIED**] — after flavor selection calls N4, then N5; adds `gaps: GapReport[]` to return | call | → N4, → N5 | → U2, → P0 |
+
+**Schema change:** Add `gaps?: GapReport[]` to `OrchestratorResult` interface in `src/domain/ports/stage-orchestrator.ts`. Also add `gaps` to the destructured return in `run()` and include in result.
+
+---
+
+### P3 — reflect phase (rule suggestions, #49 MVP)
+
+New private method:
+
+| #  | Place | Component                  | Affordance                                              | Control | Wires Out  | Returns To     |
+| -- | ----- | -------------------------- | ------------------------------------------------------- | ------- | ---------- | -------------- |
+| N7 | P3    | BaseStageOrchestrator      | `generateRuleSuggestions(decisions, decisionOutcomes): string[]` — filters decisions for `decisionType === 'flavor-selection'`; for each, finds outcome quality from decisionOutcomes; `'good'` → boost suggestion (name=flavor, condition=bet keywords from decision.context, magnitude=0.3, confidence=0.6); `'poor'` → penalize; calls N8 per suggestion; returns suggestion IDs | call | → N8 | → N9 |
+| N8 | P4    | RuleRegistry               | `ruleRegistry.suggestRule(suggestion)` — non-fatal: wrapped in try/catch, logs warn on failure | call | → U4, → S3 | → N7 |
+| N9 | P3    | BaseStageOrchestrator      | `reflect(decisions, flavorResults)` [**MODIFIED**] — after existing outcome recording, calls N7 with `decisions` and the `decisionOutcomes` already built; populates `ReflectionResult.ruleSuggestions` | call | → N7 | → U3, → P0 |
+
+**Outcome source:** `decisionOutcomes` is already built by `reflect()` before N7 is called — it pairs each decision ID with its outcome. `Decision.selection` gives the selected flavor name.
+
+**Bet keyword extraction for condition:** From `decision.context.bet` (typed as `Record<string, unknown>`), extract title/description as a short string (max 50 chars) for the suggestion condition.
+
+---
+
+## Data Stores
+
+| #  | Place | Store                                              | Description                                           |
+| -- | ----- | -------------------------------------------------- | ----------------------------------------------------- |
+| S1 | P4    | `StageRule[]` (loaded per category)                | Active rules — read by N2 via `ruleRegistry.loadRules()` |
+| S2 | P5    | `Decision[]` (in-memory + decisions.jsonl)         | All decisions for this run — written by N5, read by N9 |
+| S3 | P4    | `RuleSuggestion[]` (pending, on disk)              | Suggestions awaiting review — written by N8 |
+| S4 | P2    | `this.vocabulary?.keywords: string[]`              | Stage vocabulary keywords — read by N4 for gap analysis (in-memory, loaded at construction) |
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TB
+    trigger(["orchestrator.run(stage, context)"])
+
+    subgraph P1["P1: match phase"]
+        N1["N1: evaluateRuleCondition()"]
+        N2["N2: classifyRuleEffects()"]
+        N3["N3: match() MODIFIED"]
+    end
+
+    subgraph P2["P2: planExecution phase"]
+        N4["N4: detectGaps()"]
+        N5["N5: record gap-assessment Decision"]
+        N6["N6: planExecution() MODIFIED"]
+        S4["S4: vocabulary keywords"]
+    end
+
+    subgraph P3["P3: reflect phase"]
+        N7["N7: generateRuleSuggestions()"]
+        N8["N8: suggestRule()"]
+        N9["N9: reflect() MODIFIED"]
+    end
+
+    subgraph P4["P4: RuleRegistry"]
+        S1["S1: StageRule[]"]
+        S3["S3: RuleSuggestion[]"]
+    end
+
+    subgraph P5["P5: DecisionRegistry"]
+        S2["S2: Decision[]"]
+    end
+
+    U1["U1: MatchReport\n(annotated)"]
+    U2["U2: OrchestratorResult.gaps\nGapReport[]"]
+    U3["U3: ReflectionResult.ruleSuggestions\nstring[]"]
+    U4["U4: suggestion file\non disk"]
+
+    trigger --> N3
+    trigger --> N6
+    trigger --> N9
+
+    S1 -.->|loadRules| N3
+    N3 --> N2
+    N2 --> N1
+    N1 -.-> N2
+    N2 -.-> N3
+    N3 -.-> U1
+    U1 -.-> N6
+
+    S4 -.->|read| N4
+    N6 --> N4
+    N4 -.-> N6
+    N6 --> N5
+    N5 --> S2
+    N6 -.-> U2
+
+    N9 --> N7
+    N7 --> N8
+    N8 --> S3
+    N8 --> U4
+    N8 -.-> N7
+    N7 -.-> N9
+    N9 --> U3
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+    classDef store fill:#e6e6fa,stroke:#9370db,color:#000
+    classDef trigger fill:#90EE90,stroke:#228B22,color:#000
+
+    class U1,U2,U3,U4 ui
+    class N1,N2,N3,N4,N5,N6,N7,N8,N9 nonui
+    class S1,S2,S3,S4 store
+    class trigger trigger
+```
+
+---
+
+## Vertical Slices
+
+### Slice Summary
+
+| #  | Slice                    | Shape parts | Closes | Demo                                                                                     |
+| -- | ------------------------ | ----------- | ------ | ---------------------------------------------------------------------------------------- |
+| V1 | Rule effects on scoring  | A1          | #103   | Rules with boost/penalize change MatchReport.score; require adds to pinned; exclude adds to excluded |
+| V2 | Gap analysis in plan     | A2          | #104   | Bet mentioning vocabulary keywords not covered by selected flavor → non-empty GapReport[] in result |
+| V3 | Reflect suggestions (MVP)| A3          | #49 partial | After stage with flavor-selection decisions, RuleRegistry has pending suggestions with correct effect |
+
+---
+
+### V1: Rule Effects on Scoring
+
+**Demo:** A stage run where active rules include a boost for `"codebase-analysis"` with condition `"auth"` and the bet contains "authentication" → `MatchReport.score` for that flavor is higher than base; `ruleAdjustments` field is non-zero; reasoning mentions the rule.
+
+**Affordances added:**
+
+| #  | Component             | Affordance                          | Control | Wires Out | Returns To |
+| -- | --------------------- | ----------------------------------- | ------- | --------- | ---------- |
+| N1 | BaseStageOrchestrator | `evaluateRuleCondition()`           | call    | —         | → N2       |
+| N2 | BaseStageOrchestrator | `classifyRuleEffects()`             | call    | → N1      | → N3       |
+| N3 | BaseStageOrchestrator | `match()` [MODIFIED]                | call    | → N2      | → U1       |
+| U1 | MatchReport           | annotated `ruleAdjustments+reasoning` | return | —         | —          |
+
+**Files changed:**
+- `src/domain/services/stage-orchestrator.ts` — add N1, N2; modify N3/match(), replace `computeRuleAdjustments()` stub
+
+**Tests:** `stage-orchestrator.test.ts` — boost rule increases score, penalize decreases, require adds to pinned, exclude adds to excluded, precedence: exclude wins over require.
+
+---
+
+### V2: Gap Analysis in Plan Phase
+
+**Demo:** Run with vocabulary containing keyword "typescript" and bet title "Add TypeScript module" but selected flavor is "api-design" (no "typescript" in name/description) → `result.gaps` contains one `GapReport` with description mentioning "typescript" and suggestedFlavors pointing to any available flavor that covers it.
+
+**Affordances added:**
+
+| #  | Component             | Affordance                          | Control | Wires Out | Returns To |
+| -- | --------------------- | ----------------------------------- | ------- | --------- | ---------- |
+| N4 | BaseStageOrchestrator | `detectGaps()`                      | call    | —         | → N6       |
+| N5 | DecisionRegistry      | `record(gap-assessment)`            | call    | → S2      | —          |
+| N6 | BaseStageOrchestrator | `planExecution()` [MODIFIED]        | call    | → N4, → N5 | → U2      |
+| U2 | OrchestratorResult    | `gaps?: GapReport[]` NEW field      | return  | —         | —          |
+
+**Files changed:**
+- `src/domain/services/stage-orchestrator.ts` — add N4; modify N6/planExecution()
+- `src/domain/ports/stage-orchestrator.ts` — add `gaps?: GapReport[]` to `OrchestratorResult`
+
+**Tests:** `stage-orchestrator.test.ts` — no vocabulary → empty gaps; bet keyword in vocab AND covered by flavor → empty; bet keyword in vocab AND not covered → gap with correct severity and suggestedFlavors.
+
+---
+
+### V3: Reflect Suggestions (MVP)
+
+**Demo:** Stage run where executor returns a synthesis artifact (good outcome). `reflect()` records outcomes for decisions. A flavor-selection decision with `artifactQuality: 'good'` → `RuleRegistry.getPendingSuggestions()` returns one boost suggestion for the selected flavor.
+
+**Affordances added:**
+
+| #  | Component             | Affordance                          | Control | Wires Out | Returns To |
+| -- | --------------------- | ----------------------------------- | ------- | --------- | ---------- |
+| N7 | BaseStageOrchestrator | `generateRuleSuggestions()`         | call    | → N8      | → N9       |
+| N8 | RuleRegistry          | `suggestRule()` (non-fatal)         | call    | → S3      | → N7       |
+| N9 | BaseStageOrchestrator | `reflect()` [MODIFIED]              | call    | → N7      | → U3       |
+| U3 | ReflectionResult      | `ruleSuggestions` populated         | return  | —         | —          |
+
+**Files changed:**
+- `src/domain/services/stage-orchestrator.ts` — add N7; modify N9/reflect()
+
+**Tests:** `stage-orchestrator.test.ts` — good outcome flavor-selection decision → boost suggestion in registry; poor outcome → penalize suggestion; no rule registry → no crash; partial outcome → no suggestion generated (only good/poor trigger suggestions).
+
+---
+
+## Scope Coverage Verification
+
+| Req | Requirement                                           | Affordances | Covered? |
+| --- | ----------------------------------------------------- | ----------- | -------- |
+| R0  | Wire orchestration intelligence loop                  | V1+V2+V3    | Yes      |
+| R1  | Rule effects change flavor scores                     | N1, N2, N3  | Yes      |
+| R2  | Rule precedence: exclude > require > boost/penalize   | N2, N3      | Yes      |
+| R3  | Rule condition matching against capability profile    | N1          | Yes      |
+| R4  | Rule applications logged in MatchReport reasoning     | N3 (annotation) | Yes  |
+| R5  | Gap analysis produces GapReport[] after flavor select | N4, N6, U2  | Yes      |
+| R6  | Gap analysis records gap-assessment Decision          | N5          | Yes      |
+| R7  | Reflect generates suggestions via suggestRule()       | N7, N8, U3  | Yes      |
+| R8  | MVP reflect — current stage only, no history          | N7 (local only) | Yes  |
+| R9  | Session fit: ≥2 closed issues                         | V1(#103) + V2(#104) | Yes |
+| R10 | No cooldown (#45)                                     | Not in scope | Yes (out) |
+| R11 | No #49 stretch goals                                  | Not in scope | Yes (out) |
+| R12 | No #105 flavor/manifest layer                         | Not in scope | Yes (out) |
+
+---
+
+## Decision Points Log
+
+| # | Decision                                      | Options                          | Selected               | Reason |
+| - | --------------------------------------------- | -------------------------------- | ---------------------- | ------ |
+| 1 | Gap severity heuristic                        | Vocabulary index-based, keyword weight, flat medium | Index-based (first-third=high, second-third=medium, rest=low) | Simple, deterministic, no config needed |
+| 2 | `OrchestratorResult.gaps` field               | Add to port interface, add to internal result only | Add to port interface | Needed for tests and future kata status display |
+| 3 | Suggest only for good/poor (not partial)      | All outcomes, only extremes | good/poor only | Partial outcomes are ambiguous — don't generate low-confidence suggestions |
+| 4 | Rule.name = flavor name convention            | Schema change (add flavorTarget field), use name, use condition | Use `name` = flavor name | No schema change; convention documented in breadboard and code comments |
+| 5 | planExecution return type                     | Keep internal return, expose via OrchestratorResult | Expose via OrchestratorResult only | Tests can assert on final result; internal return stays narrow |

--- a/docs/workspace/20260225-wave-c-s1/frame.md
+++ b/docs/workspace/20260225-wave-c-s1/frame.md
@@ -1,0 +1,68 @@
+---
+shaping: true
+---
+
+# Wave C Session 1 — Frame
+
+## Source
+
+> Wave C Session 1 — Orchestration Rule Wiring + Reflect Phase
+>
+> Issues: #103 (rule wiring), #104 (gap analysis), #105 (resources), #49 (reflect phase), #45 (cooldown integration)
+>
+> Reference files:
+> - docs/v1-product-spec.md — authoritative spec
+> - skill/orchestration.md — current orchestration rules and gaps
+> - src/domain/types/run-state.ts — Decision/StageState schemas
+> - src/infrastructure/orchestration/ — RuleRegistry, DecisionRegistry, MetaOrchestrator
+>
+> Acceptance criteria: At least one GitHub issue closed with tests passing, a completed
+> breadboard-reflection doc, and skill/orchestration.md updated to remove any remaining
+> gaps addressed.
+
+---
+
+## Problem
+
+The 6-phase orchestration loop (`BaseStageOrchestrator`) has all its intelligence
+phases implemented as stubs:
+
+1. **Rules have no effect** — `computeRuleAdjustments()` returns 0. The RuleRegistry
+   is fully built (CRUD, suggest/accept/reject) but rules never change flavor scores.
+   Boost/penalize/require/exclude effects are all no-ops. (#103)
+
+2. **Gaps are never detected** — `ExecutionPlan.gaps` exists in the schema and the
+   plan phase runs, but coverage analysis is never performed. Gap data doesn't flow
+   into stage state.json or any downstream consumer. (#104)
+
+3. **Reflect phase never suggests rules** — `reflect()` has the structure to generate
+   `ruleSuggestions` but the code is explicitly marked "no-op — infrastructure ready."
+   The self-improvement loop cannot operate. (#49)
+
+The result: every run is blind. Rules learned from past executions don't influence
+future flavor selection. Gaps in methodology coverage are never surfaced. The
+reflect phase accumulates no learnings that feed back into improved orchestration.
+
+The system is a skeleton with the intelligence layers unconnected.
+
+---
+
+## Outcome
+
+After this session:
+
+- Rule effects (boost/penalize/require/exclude) actively change what flavors are
+  selected and how they're scored during the match phase.
+- The plan phase detects coverage gaps — bet context keywords not addressed by any
+  selected flavor — and stores them in stage state for downstream visibility.
+- The reflect phase generates concrete rule suggestions from decision outcomes and
+  stores them via `RuleRegistry.suggestRule()` for the user's review workflow.
+- At least one GitHub issue is closed with full test coverage.
+- `skill/orchestration.md` is updated to reflect the new capabilities.
+
+**Out of scope this session:**
+- Cooldown ↔ run data integration (#45 — XL, blocked by #49)
+- Orchestrator history consultation and vocabulary enrichment (#49 stretch goals)
+- `kata knowledge rules --pending` CLI command (#49 stretch goal)
+- Flavor-level resource aggregation and ManifestBuilder integration (#105 — step-level
+  output already works via `kata step next`)

--- a/docs/workspace/20260225-wave-c-s1/impl-plan.md
+++ b/docs/workspace/20260225-wave-c-s1/impl-plan.md
@@ -1,0 +1,437 @@
+---
+impl-plan: true
+pipeline: 20260225-wave-c-s1
+issues: "#103, #104, #49"
+---
+
+# Wave C Session 1 — Implementation Plan
+
+> Generated from breadboard at `docs/workspace/20260225-wave-c-s1/breadboard.md`.
+> Shape: A (in-place wiring). Slices: V1 (#103), V2 (#104), V3 (#49 MVP).
+
+---
+
+## Pre-Flight Checks
+
+| Risk | Status | Notes |
+|------|--------|-------|
+| All domain types already exist | ✅ Verified | `GapReport`, `ExecutionPlan.gaps`, `ReflectionResult.ruleSuggestions`, `DecisionType['gap-assessment']` — no schema changes |
+| `OrchestratorResult` port needs `gaps` | ⚠️ 1 line | Port interface missing `readonly gaps?: GapReport[]` |
+| `computeRuleAdjustments()` return not wired to `score` | ⚠️ Known stub | `score: base` ignores ruleAdj — must fix |
+| 1 existing test counts `record` calls at exactly 4 | ⚠️ Fix in Step 4a | Gap-assessment adds 5th call; update assertion to 5 |
+| `RuleSuggestion.suggestedRule` requires full `StageRuleSchema` shape | ✅ Verified | `source: 'auto-detected'`, `evidence: [decisionId]` covers all required fields |
+| Layer violations | ✅ None | All changes stay in `domain/services/` + `domain/ports/` |
+
+---
+
+## Scope Summary
+
+| File | Changes | Closes |
+|------|---------|--------|
+| `src/domain/ports/stage-orchestrator.ts` | +1 field to `OrchestratorResult` | — |
+| `src/domain/services/stage-orchestrator.ts` | +5 methods, ~3 modified, 1 removed | #103 #104 #49 |
+| `src/domain/services/stage-orchestrator.test.ts` | Fix 1 test, +3 describe blocks (~24 tests) | — |
+| `skill/orchestration.md` | Remove stub language, describe active behavior | — |
+
+**Total: 4 files, 0 new files, 0 new dependencies, 0 layer violations.**
+
+---
+
+## Step 0 — Port Interface (unblocks type checking for all steps)
+
+**File:** `src/domain/ports/stage-orchestrator.ts`
+
+- Add `GapReport` to the import from `@domain/types/orchestration.js`
+- Add `readonly gaps?: GapReport[]` to `OrchestratorResult`
+
+_Optional field for backward-compatibility — tests without vocabulary get `undefined`._
+
+---
+
+## Step 1 — V1: Rule Effects in `match()` (#103)
+
+**File:** `src/domain/services/stage-orchestrator.ts`
+
+### 1a. Imports
+
+Add `GapReport` to existing orchestration import. Add:
+```ts
+import type { StageRule } from '@domain/types/rule.js';
+```
+
+### 1b. Module-level stop words constant
+
+```ts
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'have', 'has',
+  'do', 'does', 'will', 'would', 'could', 'should', 'may', 'might', 'to',
+  'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'or', 'and', 'but',
+  'not', 'this', 'that', 'it', 'if', 'when', 'then', 'there', 'which', 'who',
+]);
+```
+
+### 1c. Internal type (add near other internal types)
+
+```ts
+interface ClassifiedRules {
+  excluded: Set<string>;
+  required: Set<string>;
+  adjustments: Map<string, number>;
+}
+```
+
+### 1d. New private method: `evaluateRuleCondition()`
+
+```ts
+private evaluateRuleCondition(
+  rule: StageRule,
+  bText: string,
+  artifacts: readonly string[],
+  category: string,
+): boolean {
+  const words = rule.condition
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !STOP_WORDS.has(w));
+
+  if (words.length === 0) return false;
+
+  const haystack = [bText, category, ...artifacts.map((a) => a.toLowerCase())].join(' ');
+  return words.some((w) => haystack.includes(w));
+}
+```
+
+### 1e. New private method: `classifyRuleEffects()`
+
+```ts
+private classifyRuleEffects(
+  rules: StageRule[],
+  context: OrchestratorContext,
+): ClassifiedRules {
+  const excluded = new Set<string>();
+  const required = new Set<string>();
+  const adjustments = new Map<string, number>();
+  const bText = betText(context);
+
+  for (const rule of rules) {
+    if (!this.evaluateRuleCondition(rule, bText, context.availableArtifacts, this.stageCategory)) {
+      continue;
+    }
+    switch (rule.effect) {
+      case 'exclude':
+        excluded.add(rule.name);
+        break;
+      case 'require':
+        required.add(rule.name);
+        break;
+      case 'boost':
+        adjustments.set(rule.name, (adjustments.get(rule.name) ?? 0) + rule.magnitude * rule.confidence);
+        break;
+      case 'penalize':
+        adjustments.set(rule.name, (adjustments.get(rule.name) ?? 0) - rule.magnitude * rule.confidence);
+        break;
+    }
+  }
+  return { excluded, required, adjustments };
+}
+```
+
+### 1f. Remove `computeRuleAdjustments()` stub (entire private method deleted)
+
+### 1g. Modify `match()`
+
+After building `excluded` and `pinned` from stage config but BEFORE filtering `candidateNames`, insert:
+
+```ts
+// Apply rule effects to excluded/pinned sets and compute per-flavor score adjustments
+const ruleAdjMap = new Map<string, number>();
+const firedRuleNames: string[] = [];
+if (this.deps.ruleRegistry) {
+  const rules = this.deps.ruleRegistry.loadRules(this.stageCategory);
+  const classified = this.classifyRuleEffects(rules, context);
+  for (const name of classified.excluded) excluded.add(name);
+  for (const name of classified.required) {
+    if (!excluded.has(name)) pinned.add(name);
+  }
+  for (const [name, adj] of classified.adjustments) {
+    ruleAdjMap.set(name, adj);
+  }
+  firedRuleNames.push(...classified.excluded, ...classified.required, ...classified.adjustments.keys());
+}
+```
+
+In the `matchReports` candidates mapping:
+- Replace `const ruleAdj = this.computeRuleAdjustments(flavor)` with `const ruleAdj = ruleAdjMap.get(flavor.name) ?? 0`
+- Change `score: base` to `score: Math.max(0, Math.min(1, base + ruleAdj))`
+- Annotate reasoning: append ` Rule fired for "${flavor.name}".` when `firedRuleNames.includes(flavor.name)`
+
+---
+
+## Step 2 — V2: Gap Analysis in `planExecution()` (#104)
+
+### 2a. New private method: `detectGaps()`
+
+```ts
+private detectGaps(
+  selectedFlavors: Flavor[],
+  allFlavors: Flavor[],
+  context: OrchestratorContext,
+): GapReport[] {
+  const keywords = this.vocabulary?.keywords ?? [];
+  if (keywords.length === 0) return [];
+
+  const bText = betText(context);
+  const selectedNames = new Set(selectedFlavors.map((f) => f.name));
+
+  // Build coverage set from selected flavor names + descriptions
+  const covered = new Set<string>();
+  for (const flavor of selectedFlavors) {
+    const text = [flavor.name, flavor.description ?? ''].join(' ').toLowerCase();
+    for (const word of text.split(/\s+/)) {
+      if (word.length > 2) covered.add(word);
+    }
+  }
+
+  const gaps: GapReport[] = [];
+  const total = keywords.length;
+
+  keywords.forEach((keyword, index) => {
+    const kwLower = keyword.toLowerCase();
+    if (!bText.includes(kwLower)) return; // not in bet context — not a gap
+    if (covered.has(kwLower)) return;     // covered by selected flavor — not a gap
+
+    const suggestedFlavors = allFlavors
+      .filter((f) => !selectedNames.has(f.name))
+      .filter((f) => [f.name, f.description ?? ''].join(' ').toLowerCase().includes(kwLower))
+      .map((f) => f.name);
+
+    const severity: 'high' | 'medium' | 'low' =
+      index < Math.ceil(total / 3) ? 'high'
+      : index < Math.ceil((2 * total) / 3) ? 'medium'
+      : 'low';
+
+    gaps.push({
+      description: `Bet context mentions "${keyword}" but no selected flavor covers it.`,
+      severity,
+      suggestedFlavors,
+    });
+  });
+
+  return gaps;
+}
+```
+
+### 2b. Modify `planExecution()` return type
+
+Add `gaps: GapReport[]` to the returned shape.
+
+### 2c. In `planExecution()`, after building `selected`, add:
+
+```ts
+// Gap analysis: detect vocabulary coverage gaps after flavor selection
+const allFlavors = [...candidates, ...pinnedFlavors];
+const gaps = this.detectGaps(selected, allFlavors, context);
+
+// Record gap-assessment decision (non-fatal — gap analysis is informational)
+try {
+  this.deps.decisionRegistry.record({
+    stageCategory: this.stageCategory,
+    decisionType: 'gap-assessment',
+    context: {
+      gapCount: gaps.length,
+      gaps,
+      selectedFlavors: selected.map((f) => f.name),
+    },
+    options: ['gaps-found', 'no-gaps'],
+    selection: gaps.length > 0 ? 'gaps-found' : 'no-gaps',
+    reasoning:
+      gaps.length > 0
+        ? `Found ${gaps.length} coverage gap(s): ${gaps.map((g) => g.description).join('; ')}`
+        : 'No coverage gaps detected — selected flavors cover bet context keywords.',
+    confidence: 0.8,
+    decidedAt: new Date().toISOString(),
+  });
+} catch (err) {
+  logger.warn(
+    `Orchestrator: failed to record gap-assessment decision: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+return { selectedFlavors: selected, executionMode, selectionDecision, modeDecision, gaps };
+```
+
+### 2d. Modify `run()`
+
+Destructure `gaps` from `planExecution()` call and add to final return object.
+
+---
+
+## Step 3 — V3: Reflect Suggestions in `reflect()` (#49 MVP)
+
+### 3a. New private method: `generateRuleSuggestions()`
+
+```ts
+private generateRuleSuggestions(
+  decisions: Decision[],
+  decisionOutcomes: ReflectionResult['decisionOutcomes'],
+): string[] {
+  if (!this.deps.ruleRegistry) return [];
+
+  const suggestionIds: string[] = [];
+
+  for (const decision of decisions) {
+    if (decision.decisionType !== 'flavor-selection') continue;
+
+    const outcomeEntry = decisionOutcomes.find((o) => o.decisionId === decision.id);
+    if (!outcomeEntry) continue;
+
+    const quality = outcomeEntry.outcome.artifactQuality;
+    if (quality !== 'good' && quality !== 'poor') continue;
+
+    const effect: 'boost' | 'penalize' = quality === 'good' ? 'boost' : 'penalize';
+    const flavorName = decision.selection;
+
+    // Build condition from bet context stored in the flavor-selection decision
+    const bet = decision.context['bet'] as Record<string, unknown> | undefined;
+    const betTitle = typeof bet?.['title'] === 'string' ? String(bet['title']) : '';
+    const betDesc = typeof bet?.['description'] === 'string' ? String(bet['description']) : '';
+    const conditionBase = `${betTitle} ${betDesc}`.trim().slice(0, 50);
+    const condition =
+      conditionBase.length > 0
+        ? `pattern from "${conditionBase}" context`
+        : `pattern from ${this.stageCategory} context`;
+
+    try {
+      const suggestion = this.deps.ruleRegistry.suggestRule({
+        suggestedRule: {
+          category: this.stageCategory,
+          name: flavorName,
+          condition,
+          effect,
+          magnitude: 0.3,
+          confidence: 0.6,
+          source: 'auto-detected',
+          evidence: [decision.id],
+        },
+        triggerDecisionIds: [decision.id],
+        observationCount: 1,
+        reasoning: `Flavor "${flavorName}" had ${quality} outcome during ${this.stageCategory} stage.`,
+      });
+      suggestionIds.push(suggestion.id);
+    } catch (err) {
+      logger.warn(
+        `Reflect: failed to generate rule suggestion for flavor "${flavorName}": ${err instanceof Error ? err.message : String(err)}`,
+        { flavorName, effect },
+      );
+    }
+  }
+
+  return suggestionIds;
+}
+```
+
+### 3b. Modify `reflect()`
+
+Replace the no-op block:
+```ts
+// REMOVE:
+const ruleSuggestions: string[] = [];
+if (this.deps.ruleRegistry && flavorResults.length > 1) {
+  // Future: analyze patterns... no-op
+}
+
+// REPLACE WITH:
+const ruleSuggestions = this.generateRuleSuggestions(decisions, decisionOutcomes);
+```
+
+---
+
+## Step 4 — Tests (`stage-orchestrator.test.ts`)
+
+### 4a. Fix 1 broken test (MUST fix before adding new tests)
+
+```ts
+// Line ~182: was 4, becomes 5 (gap-assessment adds a record() call)
+expect(deps.decisionRegistry.record).toHaveBeenCalledTimes(5);
+```
+
+### 4b. Add `makeRuleRegistry()` mock factory
+
+```ts
+function makeRuleRegistry(rules: StageRule[] = []): IStageRuleRegistry {
+  return {
+    loadRules: vi.fn(() => rules),
+    addRule: vi.fn((input) => ({ ...input, id: randomUUID(), createdAt: new Date().toISOString() })),
+    removeRule: vi.fn(),
+    suggestRule: vi.fn((input) => ({
+      ...input,
+      id: randomUUID(),
+      status: 'pending' as const,
+      createdAt: new Date().toISOString(),
+    })),
+    getPendingSuggestions: vi.fn(() => []),
+    acceptSuggestion: vi.fn(),
+    rejectSuggestion: vi.fn(),
+  };
+}
+```
+
+Also need: `import { randomUUID } from 'node:crypto'` and `import type { StageRule } from '@domain/types/rule.js'` and `import type { IStageRuleRegistry } from '@domain/ports/rule-registry.js'`.
+
+### 4c. New describe block: `'run() — rule wiring (#103)'` (~12 tests)
+
+Key scenarios:
+- Boost rule with condition word in bet title → `matchReports[n].ruleAdjustments > 0`, score increased vs base
+- Penalize rule → score decreased, clamped at 0
+- Multiple boost rules on same flavor → adjustments stack additively
+- Exclude rule matching condition → flavor absent from `selectedFlavors`
+- Require rule matching condition → flavor present in `selectedFlavors` even if not top-scored
+- Exclude wins over require when both match same flavor name
+- Condition word in stageCategory → rule fires
+- Condition word in artifact name → rule fires
+- Condition with only stop words → rule does not fire
+- No ruleRegistry → no crash, `ruleAdjustments: 0` in all match reports
+- Matching rule name annotated in MatchReport reasoning string
+
+### 4d. New describe block: `'run() — gap analysis (#104)'` (~7 tests)
+
+Key scenarios:
+- No vocabulary → `result.gaps` is `undefined` or empty array
+- All vocab keywords covered by selected flavor name/description → empty gaps
+- Vocab keyword in bet context + not covered by selected flavor → 1 GapReport with correct description
+- First-third keyword by index → severity 'high'; middle-third → 'medium'; last-third → 'low'
+- Unselected flavor name/description contains keyword → appears in `gap.suggestedFlavors`
+- Keyword in vocabulary but NOT in bet context → no gap created
+- Gap-assessment decision recorded: `decisionRegistry.record` called with `decisionType: 'gap-assessment'`
+
+### 4e. New describe block: `'run() — reflect suggestions (#49 MVP)'` (~5 tests)
+
+Key scenarios:
+- Good outcome + ruleRegistry present → `reflection.ruleSuggestions` has 1 UUID; `ruleRegistry.suggestRule` called with `effect: 'boost'`
+- No ruleRegistry → `reflection.ruleSuggestions` is empty, no crash
+- Partial outcome (neither 'good' nor 'poor') → no suggestion generated
+- `reflection.ruleSuggestions[0]` is the UUID returned by `suggestRule()`
+- `ruleRegistry.suggestRule()` throws → non-fatal: empty suggestions, no crash
+
+---
+
+## Step 5 — Update `skill/orchestration.md`
+
+- Remove all language describing rule wiring, gap analysis, reflect as "stub", "no-op", "infrastructure ready, not yet wired"
+- Update the intelligence phases section to describe active behavior:
+  - Rule condition matching: keyword extraction from `rule.condition` vs bet text + artifacts + stageCategory
+  - Gap detection: vocabulary keyword coverage analysis in `planExecution()`, surfaced in `OrchestratorResult.gaps`
+  - MVP reflect: analyzes `flavor-selection` decisions with good/poor outcomes, calls `ruleRegistry.suggestRule()`
+
+---
+
+## Implementation Order
+
+```
+Step 0 → Step 1 → run tests (V1 only, ~12 new pass) →
+Step 2 → run tests (V2 added, fix broken test) →
+Step 3 → run tests (V3 added) →
+Step 4 (all tests green) →
+Step 5 (skill doc update) →
+/breadboard-reflection
+```

--- a/docs/workspace/20260225-wave-c-s1/shaping.md
+++ b/docs/workspace/20260225-wave-c-s1/shaping.md
@@ -1,0 +1,154 @@
+---
+shaping: true
+---
+
+# Wave C Session 1 — Shaping
+
+## Requirements (R)
+
+| ID   | Requirement                                                                                  | Status    |
+| ---- | -------------------------------------------------------------------------------------------- | --------- |
+| R0   | Wire the orchestration intelligence loop: rules affect scoring, gaps are detected, reflect generates suggestions | Core goal |
+| R1   | #103: Rule effects (boost/penalize/require/exclude) change flavor scores and selection during the match phase | Must-have |
+| R2   | #103: Rule precedence: exclude > require; penalize/boost stack additively; rule confidence weights magnitude | Must-have |
+| R3   | #103: Rule condition matching against capability profile (bet context, artifacts, stage category) | Must-have |
+| R4   | #103: Rule applications logged in MatchReport reasoning (which rule fired, what effect)      | Must-have |
+| R5   | #104: After flavor selection, vocabulary coverage gap analysis produces GapReport[] entries  | Must-have |
+| R6   | #104: Gap analysis records a `gap-assessment` Decision                                       | Must-have |
+| R7   | #49: Reflect phase generates rule suggestions from decision outcomes via RuleRegistry.suggestRule() | Must-have |
+| R8   | #49: Minimum viable scope: analyze flavor-selection decisions from current stage only (no cross-run history consultation) | Must-have |
+| R9   | Session fit: scope delivers ≥2 closed issues (#103 + #104 mandatory; #49 on track)          | Must-have |
+| R10  | No-go: Cooldown ↔ run data integration (#45) — XL effort, blocked by #49                   | Out       |
+| R11  | No-go: Orchestrator history consultation, vocabulary enrichment, `kata knowledge rules --pending` CLI (#49 stretch) | Out       |
+| R12  | No-go: Flavor-level resource aggregation + ManifestBuilder integration (#105) — step-level already works | Out       |
+
+---
+
+## Design Decision: Rule Condition Matching
+
+`StageRule.condition` is a human-readable string (e.g., "when bet contains auth keywords").
+How do we evaluate it in code?
+
+**Options considered:**
+
+| Option | Mechanism | Tradeoff |
+| ------ | --------- | -------- |
+| Keyword extraction | Split condition on spaces, check if any words appear in betText + stageCategory + artifact names | Simple, v1-appropriate, some false positives |
+| Structured predicates | Named evaluator registry, condition is a key like `"bet-has:auth"` | Better precision, requires schema change |
+| LLM evaluation | Agent reads condition and evaluates | Not appropriate — kata is not an agent runtime |
+
+**Decision**: Keyword extraction. For v1, rules are authored by agents or users who understand
+the convention. Filter out common stop words. Match significant words from condition against
+capability profile. Condition confidence (rule.confidence) weights the magnitude anyway, so
+imprecise matches degrade gracefully.
+
+---
+
+## A: In-Place Wiring with Classified Rule Effects
+
+Wire all three intelligence phases directly in `BaseStageOrchestrator`. No new abstraction
+classes. Small-diff changes to existing methods + one new private helper.
+
+| Part   | Mechanism                                                                                    | Flag |
+| ------ | -------------------------------------------------------------------------------------------- | :--: |
+| **A1** | **Rule evaluation in `match()` phase (#103)**                                                |      |
+| A1.1   | `evaluateRuleCondition(rule, profile)` private helper: extracts meaningful words from `rule.condition`, checks against betText, artifact names, stageCategory | |
+| A1.2   | Classify active rules by effect: `excluded` set (exclude rules that fire), `required` set (require rules that fire), `adjustments` Map<flavorName, number> (boost/penalize) | |
+| A1.3   | Merge rule-excluded names into `excluded` set (before pinnedFlavors check — exclude wins) | |
+| A1.4   | Merge rule-required flavor names into `pinned` set (after excluded — require loses to exclude) | |
+| A1.5   | Compute score adjustment per flavor: `Σ (±magnitude × confidence)` for all matching boost/penalize rules where flavor name matches rule.name or rule.condition | |
+| A1.6   | Add `ruleAdjustments` to flavor score in MatchReport: `score = clamp(base + ruleAdj, 0, 1)` | |
+| A1.7   | Annotate MatchReport.reasoning with which rules fired and their effects                      |      |
+| **A2** | **Gap analysis in `planExecution()` phase (#104)**                                           |      |
+| A2.1   | After flavor selection, extract covered keywords: union of words from each selected flavor's name + description | |
+| A2.2   | Extract bet context keywords from `betText()` (title, description, tags), filter stop words  | |
+| A2.3   | Gap = vocabulary keyword (from `this.vocabulary?.keywords`) in bet context not covered by any selected flavor's name/description | |
+| A2.4   | For each gap keyword: find available (unselected) flavors that mention it → `suggestedFlavors` | |
+| A2.5   | Severity heuristic: high if vocabulary keyword is a stage primary keyword; medium if secondary; low otherwise | |
+| A2.6   | Record `gap-assessment` Decision via `decisionRegistry.record()`                             |      |
+| A2.7   | Return `GapReport[]` alongside the execution plan (populate `ExecutionPlan.gaps`)            |      |
+| **A3** | **Rule suggestion generation in `reflect()` phase (#49 minimum viable)**                     |      |
+| A3.1   | Extract all `flavor-selection` decisions from the completed stage's decision list            |      |
+| A3.2   | Correlate outcome: `good` → boost suggestion for selected flavor; `poor` → penalize suggestion | |
+| A3.3   | Build suggestion with: category, condition (e.g. "pattern from `<betKeywords>` context"), effect, magnitude 0.3, confidence 0.6, evidence (decision IDs) | |
+| A3.4   | Call `ruleRegistry.suggestRule()` if registry available — non-fatal if it throws (same pattern as `updateOutcome`) | |
+| A3.5   | Populate `ReflectionResult.ruleSuggestions` with generated suggestion IDs                    |      |
+
+---
+
+## B: Extracted Collaborators
+
+Same behavior as A but each intelligence piece lives in its own class/file:
+- `RuleEvaluator` class in `src/domain/services/rule-evaluator.ts`
+- `GapAnalyzer` function/class in `src/domain/services/gap-analyzer.ts`
+- `ReflectAnalyzer` in `src/domain/services/reflect-analyzer.ts`
+
+Wire into `BaseStageOrchestrator` via constructor injection or static calls.
+
+Pros: Better testability for each component in isolation, cleaner concerns.
+Cons: More files, more wiring, more moving parts for a session-sized scope.
+     Creates premature abstraction — these are small, cohesive changes to one class.
+
+---
+
+## C: #103 Only — Rule Wiring Without Gap/Reflect
+
+Deliver rule wiring (#103) alone. Defer gap analysis (#104) and reflect (#49).
+
+Pros: Ship one issue with high confidence.
+Cons: Session goal is "wire the intelligence loop" — this delivers only ⅓ of it.
+     Gap analysis and reflect are logically coupled to rule wiring (gap suggests rules, reflect generates them).
+
+---
+
+## Fit Check
+
+| Req | Requirement                                                          | Status    | A   | B   | C   |
+| --- | -------------------------------------------------------------------- | --------- | --- | --- | --- |
+| R0  | Wire orchestration intelligence loop                                 | Core goal | ✅  | ✅  | ❌  |
+| R1  | Rule effects change flavor scores                                    | Must-have | ✅  | ✅  | ✅  |
+| R2  | Rule precedence: exclude > require > boost/penalize stack            | Must-have | ✅  | ✅  | ✅  |
+| R3  | Rule condition matching against capability profile                   | Must-have | ✅  | ✅  | ✅  |
+| R4  | Rule applications logged in MatchReport reasoning                    | Must-have | ✅  | ✅  | ✅  |
+| R5  | Gap analysis produces GapReport[] after flavor selection             | Must-have | ✅  | ✅  | ❌  |
+| R6  | Gap analysis records gap-assessment Decision                         | Must-have | ✅  | ✅  | ❌  |
+| R7  | Reflect phase generates rule suggestions via RuleRegistry.suggestRule() | Must-have | ✅  | ✅  | ❌  |
+| R8  | Minimum viable reflect — current stage only, no cross-run history    | Must-have | ✅  | ✅  | ✅  |
+| R9  | Session fit: ≥2 closed issues                                        | Must-have | ✅  | ❌  | ❌  |
+| R10 | No cooldown #45                                                      | Out       | ✅  | ✅  | ✅  |
+| R11 | No #49 stretch goals                                                 | Out       | ✅  | ✅  | ✅  |
+| R12 | No #105 flavor/manifest layer                                        | Out       | ✅  | ✅  | ✅  |
+
+**Notes:**
+- B fails R9: more files = more setup time, session too short to deliver 2+ closed issues
+- C fails R0, R5, R6, R7, R9: only wires rules, leaves gap/reflect as stubs
+
+---
+
+## Selected Shape: A
+
+Shape A wins. In-place wiring keeps diffs small and focused. The three intelligence
+phases (match rules, plan gaps, reflect suggestions) are tightly coupled and belong
+together in `BaseStageOrchestrator`. Extracting to collaborators (B) adds overhead
+without payoff at this scale.
+
+**Parts summary:**
+
+| Part | Closes | Files Changed |
+| ---- | ------ | ------------- |
+| A1   | #103   | `src/domain/services/stage-orchestrator.ts` |
+| A2   | #104   | `src/domain/services/stage-orchestrator.ts` |
+| A3   | #49 (MVP) | `src/domain/services/stage-orchestrator.ts` |
+| Tests | All   | `src/domain/services/stage-orchestrator.test.ts` |
+| Docs | All    | `skill/orchestration.md` |
+
+---
+
+## Decision Points Log
+
+| # | Decision | Options | Selected | Reason |
+| - | -------- | ------- | -------- | ------ |
+| 1 | Rule condition matching strategy | Keyword extraction, structured predicates, LLM | Keyword extraction | Simplest for v1; rule confidence weights magnitude; no schema change needed |
+| 2 | Shape selection | A (in-place), B (extracted), C (#103 only) | A | Best session fit; all three phases in one focused file |
+| 3 | #49 scope | Full (history consultation + vocab enrichment + CLI), MVP (current-stage outcomes only) | MVP | History consultation requires cross-run data (blocked by #45); CLI deferred |
+| 4 | #105 scope | Full (flavor aggregation + ManifestBuilder), Deferred (step-level already works) | Deferred | Step-level already works via kata step next; flavor aggregation is separate concern |

--- a/src/domain/ports/stage-orchestrator.ts
+++ b/src/domain/ports/stage-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { Stage, StageCategory } from '@domain/types/stage.js';
 import type { Flavor } from '@domain/types/flavor.js';
 import type { Decision } from '@domain/types/decision.js';
-import type { CapabilityProfile, MatchReport, ReflectionResult } from '@domain/types/orchestration.js';
+import type { CapabilityProfile, GapReport, MatchReport, ReflectionResult } from '@domain/types/orchestration.js';
 
 /**
  * A named artifact value — used for both Flavor-level synthesis artifacts
@@ -85,6 +85,8 @@ export interface OrchestratorResult {
   readonly matchReports?: MatchReport[];
   /** Reflection results from the post-execution reflect phase. */
   readonly reflection?: ReflectionResult;
+  /** Vocabulary coverage gaps detected during the plan phase. */
+  readonly gaps?: GapReport[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Wave C Session 1 — wires three intelligence phases into `BaseStageOrchestrator` and resolves all 9 issues found during code review and test review.

### Orchestration intelligence wired

- **Phase 2 Match (#103)**: `StageRule` condition keyword matching with boost/penalize/require/exclude effects. Stop-word filtering, magnitude×confidence weighting, exclude > require precedence.
- **Phase 3 Plan (#104)**: Vocabulary gap analysis — detects bet context keywords not covered by selected flavor names/descriptions. `GapReport[]` with keyword-index-based severity (first-third=high, mid=medium, last=low). Non-fatal `gap-assessment` decision recording.
- **Phase 6 Reflect (#49 MVP)**: Mines `flavor-selection` decisions for `good`/`poor` outcome quality, submits boost/penalize rule suggestions via `ruleRegistry.suggestRule()` non-fatally. Returns `ReflectionResult.ruleSuggestions`.

### Code review fixes (4)

1. **Deduplicate `loadRules()`** — loaded once in `run()`, passed to both `analyze()` and `match()` instead of loading twice per run.
2. **`learningBoost` transparency** — removed from `scoreFlavorForContext()` (was hidden in `base`), added explicitly to match score formula `base + lBoost + ruleAdj` so all components are visible in `MatchReport`.
3. **Rename `firedRuleNames` → `flavorsAffectedByRules`** — variable now accurately reflects that it tracks flavors with any rule effect (boost/penalize/require/exclude), not just "fired" rules.
4. **JSDoc on `detectGaps()`** — documents the keyword-ordering assumption that drives severity assignment.

### Test coverage fixes (5)

5. **`'poor'` artifact quality path** — changed `generateRuleSuggestions` from `private` to `protected`, exposed via `TestOrchestrator.callGenerateRuleSuggestions()`. Tests `'poor'` → `penalize` rule suggestion directly.
6. **`'partial'` overallQuality path** — tests `reflect()` directly via `TestOrchestrator.callReflect()` with null `synthesisArtifact.value` (structurally unreachable through `run()` because `synthesize()` throws first).
7. **`updateOutcome()` non-fatal** — verifies `run()` still resolves when all `updateOutcome` calls throw.
8. **`gap-assessment` record non-fatal** — verifies `run()` still resolves with computed gaps when the `gap-assessment` `record()` call throws.
9. **Mixed boost+penalize on same flavor** — verifies net `ruleAdjustments` = boost_mag − penalize_mag.

### Breadboard fixes (`/breadboard-reflection` audit)

- Corrected S4 Place column (P1→P2) and added `S4` node to Mermaid diagram
- Fixed S1 wire target (→N2 was wrong; S1 feeds N3/match, not N2/classifyRuleEffects)
- Added missing N3→N2 call wire
- Corrected line styles: N3-.->U1, N6-.->U2 (return values use dashed lines)
- Added missing N8-.->N7 return wire (suggestRule returns suggestion ID)

### Skill documentation

`skill/orchestration.md` updated with Orchestration Intelligence section documenting all three active phases and their outputs for orchestrating agents.

## Test plan

- [x] `npx vitest run src/domain/services/stage-orchestrator.test.ts` — 85 tests pass
- [x] `npx vitest run` — 1539 tests, 82 files, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)