### PR TITLE
feat(#105 #112): flavor resource aggregation + cooldown run data integration

### DIFF
--- a/skill/orchestration.md
+++ b/skill/orchestration.md
@@ -207,6 +207,40 @@ Then **pauses** — does not call `kata step next` again until approval confirma
 
 ---
 
+## Resources in `kata step next` Output
+
+`kata step next --json` includes a `resources` field containing the merged union of:
+
+1. **Step-level resources** — tools, agents, and skills declared on the step definition
+2. **Flavor-level resources** — additional tools, agents, and skills declared on the flavor itself (available across all steps in that flavor)
+
+Step definitions **win** on name conflicts — if both the step and the flavor declare a resource with the same name, the step's version is used.
+
+```json
+{
+  "status": "ready",
+  "runId": "...",
+  "stage": "build",
+  "flavor": "typescript-feature",
+  "step": "implementation-ts",
+  "prompt": "...",
+  "resources": {
+    "tools": [
+      { "name": "tsc", "purpose": "Type checking", "command": "npx tsc --noEmit" },
+      { "name": "vitest", "purpose": "Run tests", "command": "npm test" }
+    ],
+    "agents": [
+      { "name": "everything-claude-code:build-error-resolver", "when": "when build fails" }
+    ],
+    "skills": []
+  }
+}
+```
+
+The executing agent (flavor sub-agent) should consult `resources` to discover available tools, agents, and skills for the current work. If the flavor is not registered, `resources` falls back to the step's own resources.
+
+---
+
 ## Orchestration Intelligence
 
 The `BaseStageOrchestrator` runs a 6-phase loop per stage. Three phases are now active and shape flavor selection automatically — agents don't drive these directly, but the outputs are visible in `OrchestratorResult` and `kata decision list`.

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -324,6 +324,7 @@ export function registerCycleCommands(parent: Command): void {
         };
 
         createRunTree(runsDir, run);
+        manager.setRunId(cycleId, bet.id, runId);
 
         runs.push({
           runId,
@@ -411,6 +412,7 @@ export function registerCycleCommands(parent: Command): void {
         persistence: JsonStore,
         pipelineDir: kataDirPath(ctx.kataDir, 'pipelines'),
         historyDir: kataDirPath(ctx.kataDir, 'history'),
+        runsDir: kataDirPath(ctx.kataDir, 'runs'),
       });
 
       const betOutcomes: BetOutcomeRecord[] = [];
@@ -460,6 +462,7 @@ export function registerCycleCommands(parent: Command): void {
           betOutcomes: result.betOutcomes,
           proposals: result.proposals,
           learningsCaptured: result.learningsCaptured,
+          runSummaries: result.runSummaries,
         }, null, 2));
       } else {
         console.log(formatCooldownSessionResult(result));

--- a/src/cli/formatters/cycle-formatter.test.ts
+++ b/src/cli/formatters/cycle-formatter.test.ts
@@ -2,6 +2,7 @@ import type { BudgetStatus, Cycle } from '@domain/types/cycle.js';
 import type { CooldownReport, CooldownBetReport } from '@domain/services/cycle-manager.js';
 import type { CycleProposal } from '@features/cycle-management/proposal-generator.js';
 import type { CooldownSessionResult } from '@features/cycle-management/cooldown-session.js';
+import type { RunSummary } from '@features/cycle-management/types.js';
 import {
   formatCycleStatus,
   formatCooldownReport,
@@ -311,6 +312,47 @@ describe('formatCooldownSessionResult', () => {
   it('shows no-proposals message when empty', () => {
     const result = formatCooldownSessionResult(makeSessionResult());
     expect(result).toContain('No proposals generated for the next cycle.');
+  });
+
+  it('shows run summaries section when present', () => {
+    const runSummaries: RunSummary[] = [
+      {
+        betId: 'aaaaaaaa-0000-0000-0000-000000000001',
+        runId: 'rrrrrrrr-0000-0000-0000-000000000001',
+        stagesCompleted: 3,
+        gapCount: 2,
+        gapsBySeverity: { high: 1, medium: 1, low: 0 },
+        avgConfidence: 0.75,
+        artifactPaths: [],
+      },
+    ];
+    const result = formatCooldownSessionResult(makeSessionResult({ runSummaries }));
+    expect(result).toContain('--- Run Summaries ---');
+    expect(result).toContain('3 stage(s) completed');
+    expect(result).toContain('2 gap(s) [H:1 M:1 L:0]');
+    expect(result).toContain('avg confidence 75%');
+  });
+
+  it('shows null confidence as no decisions recorded', () => {
+    const runSummaries: RunSummary[] = [
+      {
+        betId: 'aaaaaaaa-0000-0000-0000-000000000002',
+        runId: 'rrrrrrrr-0000-0000-0000-000000000002',
+        stagesCompleted: 1,
+        gapCount: 0,
+        gapsBySeverity: { high: 0, medium: 0, low: 0 },
+        avgConfidence: null,
+        artifactPaths: [],
+      },
+    ];
+    const result = formatCooldownSessionResult(makeSessionResult({ runSummaries }));
+    expect(result).toContain('no decisions recorded');
+    expect(result).toContain('no gaps');
+  });
+
+  it('omits run summaries section when not provided', () => {
+    const result = formatCooldownSessionResult(makeSessionResult());
+    expect(result).not.toContain('--- Run Summaries ---');
   });
 });
 

--- a/src/cli/formatters/cycle-formatter.ts
+++ b/src/cli/formatters/cycle-formatter.ts
@@ -2,6 +2,7 @@ import type { BudgetStatus, Cycle } from '@domain/types/cycle.js';
 import type { CooldownReport, CooldownBetReport } from '@domain/services/cycle-manager.js';
 import type { CycleProposal } from '@features/cycle-management/proposal-generator.js';
 import type { CooldownSessionResult } from '@features/cycle-management/cooldown-session.js';
+import type { RunSummary } from '@features/cycle-management/types.js';
 
 /**
  * Format cycle budget status as a human-readable summary.
@@ -168,6 +169,15 @@ export function formatCooldownSessionResult(result: CooldownSessionResult): stri
     lines.push('');
   }
 
+  // Run summaries section
+  if (result.runSummaries && result.runSummaries.length > 0) {
+    lines.push('--- Run Summaries ---');
+    for (const s of result.runSummaries) {
+      lines.push(formatRunSummaryLine(s));
+    }
+    lines.push('');
+  }
+
   // Proposals section
   if (result.proposals.length > 0) {
     lines.push(formatProposals(result.proposals));
@@ -193,6 +203,16 @@ export function formatBetOutcomePrompt(bet: CooldownBetReport): string {
 }
 
 // ---- Helpers ----
+
+function formatRunSummaryLine(s: RunSummary): string {
+  const confidence = s.avgConfidence !== null
+    ? `avg confidence ${(s.avgConfidence * 100).toFixed(0)}%`
+    : 'no decisions recorded';
+  const gaps = s.gapCount > 0
+    ? `${s.gapCount} gap(s) [H:${s.gapsBySeverity.high} M:${s.gapsBySeverity.medium} L:${s.gapsBySeverity.low}]`
+    : 'no gaps';
+  return `  bet ${s.betId.slice(0, 8)}: ${s.stagesCompleted} stage(s) completed, ${gaps}, ${confidence}`;
+}
 
 function outcomeIcon(outcome: string): string {
   switch (outcome) {

--- a/src/domain/types/bet.ts
+++ b/src/domain/types/bet.ts
@@ -30,6 +30,14 @@ export const BetSchema = z.object({
   outcomeNotes: z.string().optional(),
   /** Kata execution assignment for this bet. Required by `kata cycle start`. */
   kata: KataAssignmentSchema.optional(),
+  /**
+   * UUID of the run created for this bet by `kata cycle start`.
+   *
+   * Lifecycle: set once by `kata cycle start` after `createRunTree()`; forward link
+   * for O(1) run lookup. Idempotent writes: `CycleManager.setRunId()` overwrites
+   * without error if called again (e.g., on retry). Absent until the cycle is started.
+   */
+  runId: z.string().uuid().optional(),
 });
 
 export type Bet = z.infer<typeof BetSchema>;

--- a/src/domain/types/flavor.ts
+++ b/src/domain/types/flavor.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v4';
 import { StageCategorySchema } from './stage.js';
+import { StepResourcesSchema } from './step.js';
 
 /**
  * A reference to a Step within a Flavor's ordered step list.
@@ -64,6 +65,13 @@ export const FlavorSchema = z.object({
    * Only humanApproval, confidenceThreshold, and timeout may be overridden.
    */
   overrides: z.record(z.string(), StepOverrideSchema).optional(),
+  /**
+   * Flavor-level resource additions — tools, agents, and skills available across
+   * all steps of this flavor, beyond what individual steps already declare.
+   * These are merged with step-level resources in ManifestBuilder (step wins on name conflicts).
+   * Gate conditions and artifact requirements remain non-overridable by design.
+   */
+  resources: StepResourcesSchema.optional(),
   /**
    * The artifact name this flavor produces for Stage synthesis.
    * Must be produced by one of the steps in this flavor.

--- a/src/features/cycle-management/types.ts
+++ b/src/features/cycle-management/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Summary of a single run's execution data for cooldown analysis.
+ * Loaded from .kata/runs/<run-id>/ state files by CooldownSession.loadRunSummaries().
+ * Shared between CooldownSession (which loads it) and ProposalGenerator (which consumes it).
+ */
+export interface RunSummary {
+  betId: string;
+  runId: string;
+  /** Number of stages that reached 'completed' status. */
+  stagesCompleted: number;
+  /** Total number of gaps found across all stages. */
+  gapCount: number;
+  /** Breakdown of gap counts by severity level. */
+  gapsBySeverity: { low: number; medium: number; high: number };
+  /**
+   * Average confidence across all decisions recorded in the run.
+   * null when no decisions were recorded — prevents false "low-confidence" proposals
+   * for bets where the orchestrator made no explicit decisions.
+   */
+  avgConfidence: number | null;
+  /** Relative file paths of all artifacts produced in the run. */
+  artifactPaths: string[];
+}


### PR DESCRIPTION
## Summary

- **#105** — `FlavorSchema.resources` field + `ManifestBuilder.aggregateFlavorResources()`: flavors can now declare additional tools/agents/skills that merge with (and are overridden by) step-level resources. `kata step next` wires `FlavorRegistry` to produce merged resources in manifest output.
- **#112** — Cooldown run data integration: `BetSchema.runId` forward-links bets to runs; `CycleManager.setRunId()` persists that link at run creation; `CooldownSession.loadRunSummaries()` reads per-bet run state (stages completed, gap severity breakdown, avg confidence, artifact paths); `ProposalGenerator.analyzeRunData()` converts run gaps and low confidence into prioritized next-cycle proposals; CLI `kata cooldown` passes `runsDir` and surfaces run summaries in both `--json` and formatted output.

## Verticals

| Slice | Scope |
|-------|-------|
| V1 | `FlavorSchema.resources` + `aggregateFlavorResources()` + `build()` merge |
| V2 | `kata step next` FlavorRegistry wiring + `skill/orchestration.md` docs |
| V3 | `BetSchema.runId` + `CycleManager.setRunId()` + `kata cycle start` |
| V4 | `RunSummary` type + `CooldownSession.loadRunSummaries()` |
| V5 | `ProposalGenerator.analyzeRunData()` + `sourceOrder` update |
| V6 | CLI `kata cooldown` wires `runsDir` + `--- Run Summaries ---` formatter |

## Test plan

- [x] 1573 tests passing, 82 files — no regressions
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (pre-commit hook passed)
- [x] New unit coverage: `aggregateFlavorResources` (6 tests), `build` with `flavorResources` (4 tests), `CycleManager.setRunId` (4 tests), `CooldownSession.loadRunSummaries` (5 tests), `ProposalGenerator.analyzeRunData` + `generate` (9 tests), formatter run summaries (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added detailed documentation for resources output in kata step execution, including merging behavior and conflict resolution.

* **New Features**
  * Added run tracking system to associate executions with bets and monitor run-specific details.
  * Enabled flavor-level resource definitions that merge with step resources, with step-level taking precedence.
  * Enhanced cooldown results to display run summaries with execution metrics including stages completed, gaps, and confidence data.
  * Improved proposal generation with new criteria based on execution gaps and confidence thresholds.

* **Tests**
  * Comprehensive test coverage for new run tracking, resource merging, and proposal analysis features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->