### PR TITLE
feat: rule suggestion pipeline — cooldown feedback loop (Wave C S3)

### DIFF
--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -3,7 +3,9 @@ import type { Command } from 'commander';
 import { CycleManager } from '@domain/services/cycle-manager.js';
 import { KnowledgeStore } from '@infra/knowledge/knowledge-store.js';
 import { JsonStore } from '@infra/persistence/json-store.js';
+import { RuleRegistry } from '@infra/registries/rule-registry.js';
 import { CooldownSession, type BetOutcomeRecord } from '@features/cycle-management/cooldown-session.js';
+import type { SuggestionReviewRecord } from '@features/cycle-management/types.js';
 import { withCommandContext, kataDirPath } from '@cli/utils.js';
 import {
   formatCycleStatus,
@@ -400,11 +402,13 @@ export function registerCycleCommands(parent: Command): void {
     .description('Run cooldown reflection on a completed cycle (alias: ma)')
     .argument('<cycle-id>', 'Cycle ID')
     .option('--skip-prompts', 'Skip interactive prompts')
+    .option('--auto-accept-suggestions', 'Accept all pending rule suggestions without prompts')
     .action(withCommandContext(async (ctx, cycleId: string) => {
       const localOpts = ctx.cmd.opts();
       const cyclesDir = kataDirPath(ctx.kataDir, 'cycles');
       const manager = new CycleManager(cyclesDir, JsonStore);
       const knowledgeStore = new KnowledgeStore(kataDirPath(ctx.kataDir, 'knowledge'));
+      const ruleRegistry = new RuleRegistry(kataDirPath(ctx.kataDir, 'rules'));
 
       const session = new CooldownSession({
         cycleManager: manager,
@@ -413,6 +417,7 @@ export function registerCycleCommands(parent: Command): void {
         pipelineDir: kataDirPath(ctx.kataDir, 'pipelines'),
         historyDir: kataDirPath(ctx.kataDir, 'history'),
         runsDir: kataDirPath(ctx.kataDir, 'runs'),
+        ruleRegistry,
       });
 
       const betOutcomes: BetOutcomeRecord[] = [];
@@ -456,6 +461,69 @@ export function registerCycleCommands(parent: Command): void {
 
       const result = await session.run(cycleId, betOutcomes);
 
+      // Rule suggestion review — after session.run() so suggestions are loaded
+      const suggestionReviewRecords: SuggestionReviewRecord[] = [];
+      const suggestions = result.ruleSuggestions ?? [];
+
+      if (suggestions.length > 0) {
+        if (localOpts.autoAcceptSuggestions) {
+          // Headless: accept all suggestions without prompts
+          for (const suggestion of suggestions) {
+            ruleRegistry.acceptSuggestion(suggestion.id);
+            suggestionReviewRecords.push({ id: suggestion.id, decision: 'accepted' });
+          }
+          if (!ctx.globalOpts.json) {
+            console.log(`Auto-accepted ${suggestions.length} rule suggestion(s).`);
+          }
+        } else if (!localOpts.skipPrompts) {
+          const { select, input } = await import('@inquirer/prompts');
+
+          console.log('');
+          console.log('--- Rule Suggestions ---');
+          console.log('Review pending rule suggestions:');
+          console.log('');
+
+          for (const suggestion of suggestions) {
+            const { suggestedRule, observationCount } = suggestion;
+            console.log(
+              `  [${suggestedRule.effect}] flavor "${suggestedRule.name}" — ${suggestedRule.condition} (${observationCount} observation${observationCount === 1 ? '' : 's'})`,
+            );
+
+            const decision = await select({
+              message: 'Decision:',
+              choices: [
+                { name: 'Accept', value: 'accepted' as const },
+                { name: 'Reject', value: 'rejected' as const },
+                { name: 'Defer', value: 'deferred' as const },
+              ],
+            });
+
+            if (decision === 'accepted') {
+              ruleRegistry.acceptSuggestion(suggestion.id);
+              suggestionReviewRecords.push({ id: suggestion.id, decision: 'accepted' });
+            } else if (decision === 'rejected') {
+              const reason = await input({
+                message: 'Rejection reason (optional):',
+                default: '',
+              }) || 'No reason provided';
+              ruleRegistry.rejectSuggestion(suggestion.id, reason);
+              suggestionReviewRecords.push({ id: suggestion.id, decision: 'rejected', rejectionReason: reason });
+            } else {
+              suggestionReviewRecords.push({ id: suggestion.id, decision: 'deferred' });
+            }
+          }
+        }
+      }
+
+      // Only surface a review summary when some action was taken (accept/reject/defer recorded).
+      // If --skip-prompts suppressed the loop with suggestions present, leave it undefined so
+      // the formatter shows "N pending suggestion(s) (run interactively to review)" instead.
+      const suggestionReview = suggestionReviewRecords.length > 0 ? {
+        accepted: suggestionReviewRecords.filter((r) => r.decision === 'accepted').length,
+        rejected: suggestionReviewRecords.filter((r) => r.decision === 'rejected').length,
+        deferred: suggestionReviewRecords.filter((r) => r.decision === 'deferred').length,
+      } : undefined;
+
       if (ctx.globalOpts.json) {
         console.log(JSON.stringify({
           report: result.report,
@@ -463,9 +531,11 @@ export function registerCycleCommands(parent: Command): void {
           proposals: result.proposals,
           learningsCaptured: result.learningsCaptured,
           runSummaries: result.runSummaries,
+          ruleSuggestions: result.ruleSuggestions,
+          suggestionReview,
         }, null, 2));
       } else {
-        console.log(formatCooldownSessionResult(result));
+        console.log(formatCooldownSessionResult(result, suggestionReview));
       }
     }));
 }

--- a/src/cli/commands/rules.test.ts
+++ b/src/cli/commands/rules.test.ts
@@ -1,0 +1,172 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { Command } from 'commander';
+import { RuleRegistry } from '@infra/registries/rule-registry.js';
+import { registerRuleCommands } from './rules.js';
+
+function makeSuggestionInput() {
+  return {
+    suggestedRule: {
+      category: 'build' as const,
+      name: 'Boost TypeScript flavor',
+      condition: 'When tests exist',
+      effect: 'boost' as const,
+      magnitude: 0.3,
+      confidence: 0.8,
+      source: 'auto-detected' as const,
+      evidence: ['decision-abc'],
+    },
+    triggerDecisionIds: [`00000000-0000-4000-8000-${randomUUID().slice(-12)}`],
+    observationCount: 3,
+    reasoning: 'Observed 3 times in build stages',
+  };
+}
+
+describe('kata rule commands', () => {
+  let baseDir: string;
+  let kataDir: string;
+  let rulesDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    baseDir = join(tmpdir(), `kata-rules-cmd-test-${Date.now()}`);
+    kataDir = join(baseDir, '.kata');
+    rulesDir = join(kataDir, 'rules');
+    mkdirSync(rulesDir, { recursive: true });
+
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function createProgram(): Command {
+    const program = new Command();
+    program.option('--json').option('--verbose').option('--cwd <path>');
+    program.exitOverride();
+    registerRuleCommands(program);
+    return program;
+  }
+
+  describe('kata rule accept <id>', () => {
+    it('accepts a pending suggestion and promotes it to an active rule', async () => {
+      const ruleRegistry = new RuleRegistry(rulesDir);
+      const suggestion = ruleRegistry.suggestRule(makeSuggestionInput());
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'rule', 'accept', suggestion.id,
+      ]);
+
+      // The suggestion should now be accepted
+      const refreshed = new RuleRegistry(rulesDir);
+      const pending = refreshed.getPendingSuggestions();
+      expect(pending).toHaveLength(0);
+
+      const logOutput = consoleSpy.mock.calls.map((c) => c.join('')).join('\n');
+      expect(logOutput).toContain('Accepted rule:');
+      expect(logOutput).toContain('boost');
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      const ruleRegistry = new RuleRegistry(rulesDir);
+      const suggestion = ruleRegistry.suggestRule(makeSuggestionInput());
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--json', '--cwd', baseDir,
+        'rule', 'accept', suggestion.id,
+      ]);
+
+      const logOutput = consoleSpy.mock.calls.map((c) => c.join('')).join('');
+      const parsed = JSON.parse(logOutput);
+      expect(parsed.id).toBe(suggestion.id);
+      expect(parsed.decision).toBe('accepted');
+      expect(parsed.rule).toBeDefined();
+      expect(parsed.rule.effect).toBe('boost');
+    });
+
+    it('logs an error when suggestion id does not exist', async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'rule', 'accept', '00000000-0000-4000-8000-000000000099',
+      ]);
+
+      // handleCommandError logs to console.error and sets exitCode — doesn't re-throw
+      const errorOutput = errorSpy.mock.calls.map((c) => c.join('')).join('\n');
+      expect(errorOutput).toMatch(/Error:/);
+    });
+  });
+
+  describe('kata rule reject <id> --reason <reason>', () => {
+    it('rejects a pending suggestion with a reason', async () => {
+      const ruleRegistry = new RuleRegistry(rulesDir);
+      const suggestion = ruleRegistry.suggestRule(makeSuggestionInput());
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'rule', 'reject', suggestion.id, '--reason', 'already covered',
+      ]);
+
+      // The suggestion should be rejected on disk
+      const refreshed = new RuleRegistry(rulesDir);
+      const pending = refreshed.getPendingSuggestions();
+      expect(pending).toHaveLength(0);
+
+      const logOutput = consoleSpy.mock.calls.map((c) => c.join('')).join('\n');
+      expect(logOutput).toContain(`Rejected suggestion ${suggestion.id}`);
+    });
+
+    it('outputs JSON when --json flag is set', async () => {
+      const ruleRegistry = new RuleRegistry(rulesDir);
+      const suggestion = ruleRegistry.suggestRule(makeSuggestionInput());
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--json', '--cwd', baseDir,
+        'rule', 'reject', suggestion.id, '--reason', 'not needed',
+      ]);
+
+      const logOutput = consoleSpy.mock.calls.map((c) => c.join('')).join('');
+      const parsed = JSON.parse(logOutput);
+      expect(parsed.id).toBe(suggestion.id);
+      expect(parsed.decision).toBe('rejected');
+    });
+
+    it('exits with error when --reason is missing', async () => {
+      const ruleRegistry = new RuleRegistry(rulesDir);
+      const suggestion = ruleRegistry.suggestRule(makeSuggestionInput());
+
+      const program = createProgram();
+      // Commander throws when a required option is missing (exitOverride ensures it doesn't process.exit)
+      await expect(
+        program.parseAsync([
+          'node', 'test', '--cwd', baseDir,
+          'rule', 'reject', suggestion.id,
+        ]),
+      ).rejects.toThrow();
+    });
+
+    it('logs an error when suggestion id does not exist', async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'rule', 'reject', '00000000-0000-4000-8000-000000000099', '--reason', 'test',
+      ]);
+
+      const errorOutput = errorSpy.mock.calls.map((c) => c.join('')).join('\n');
+      expect(errorOutput).toMatch(/Error:/);
+    });
+  });
+});

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -1,0 +1,47 @@
+import type { Command } from 'commander';
+import { RuleRegistry } from '@infra/registries/rule-registry.js';
+import { withCommandContext, kataDirPath } from '@cli/utils.js';
+
+/**
+ * Register the `kata rule` subcommands.
+ *
+ * Provides programmatic (LLM-friendly) rule suggestion review without requiring
+ * a full interactive cooldown session.
+ */
+export function registerRuleCommands(parent: Command): void {
+  const rule = parent
+    .command('rule')
+    .description('Manage rule suggestions — accept or reject pending suggestions');
+
+  // kata rule accept <id>
+  rule
+    .command('accept <id>')
+    .description('Accept a pending rule suggestion, promoting it to an active rule')
+    .action(withCommandContext((ctx, id: string) => {
+      const ruleRegistry = new RuleRegistry(kataDirPath(ctx.kataDir, 'rules'));
+      const acceptedRule = ruleRegistry.acceptSuggestion(id);
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify({ id, decision: 'accepted', rule: acceptedRule }, null, 2));
+      } else {
+        console.log(`Accepted rule: [${acceptedRule.effect}] ${acceptedRule.name} — ${acceptedRule.condition}`);
+      }
+    }));
+
+  // kata rule reject <id> --reason <reason>
+  rule
+    .command('reject <id>')
+    .description('Reject a pending rule suggestion with a reason')
+    .requiredOption('-r, --reason <reason>', 'Reason for rejection')
+    .action(withCommandContext((ctx, id: string) => {
+      const localOpts = ctx.cmd.opts();
+      const ruleRegistry = new RuleRegistry(kataDirPath(ctx.kataDir, 'rules'));
+      ruleRegistry.rejectSuggestion(id, localOpts.reason as string);
+
+      if (ctx.globalOpts.json) {
+        console.log(JSON.stringify({ id, decision: 'rejected' }, null, 2));
+      } else {
+        console.log(`Rejected suggestion ${id}`);
+      }
+    }));
+}

--- a/src/cli/formatters/cycle-formatter.test.ts
+++ b/src/cli/formatters/cycle-formatter.test.ts
@@ -354,6 +354,35 @@ describe('formatCooldownSessionResult', () => {
     const result = formatCooldownSessionResult(makeSessionResult());
     expect(result).not.toContain('--- Run Summaries ---');
   });
+
+  it('shows Rule Suggestions section with counts when suggestionReview is provided', () => {
+    const review = { accepted: 2, rejected: 1, deferred: 0 };
+    const result = formatCooldownSessionResult(makeSessionResult(), review);
+    expect(result).toContain('--- Rule Suggestions ---');
+    expect(result).toContain('Accepted: 2, Rejected: 1, Deferred: 0');
+  });
+
+  it('shows pending count when ruleSuggestions present but no review taken', () => {
+    const ruleSuggestions = [
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        suggestedRule: { category: 'build' as const, name: 'Boost TS', condition: 'always', effect: 'boost' as const, magnitude: 0.3, confidence: 0.8, source: 'auto-detected' as const, evidence: [] },
+        triggerDecisionIds: [],
+        observationCount: 3,
+        reasoning: 'test',
+        status: 'pending' as const,
+        createdAt: new Date().toISOString(),
+      },
+    ];
+    const result = formatCooldownSessionResult(makeSessionResult({ ruleSuggestions }));
+    expect(result).toContain('--- Rule Suggestions ---');
+    expect(result).toContain('1 pending suggestion(s) (run interactively to review)');
+  });
+
+  it('omits Rule Suggestions section when no suggestions and no review', () => {
+    const result = formatCooldownSessionResult(makeSessionResult());
+    expect(result).not.toContain('--- Rule Suggestions ---');
+  });
 });
 
 describe('formatBetOutcomePrompt', () => {

--- a/src/cli/formatters/cycle-formatter.ts
+++ b/src/cli/formatters/cycle-formatter.ts
@@ -146,7 +146,10 @@ export function formatProposalsJson(proposals: CycleProposal[]): string {
 /**
  * Format a full cooldown session result.
  */
-export function formatCooldownSessionResult(result: CooldownSessionResult): string {
+export function formatCooldownSessionResult(
+  result: CooldownSessionResult,
+  suggestionReview?: { accepted: number; rejected: number; deferred: number },
+): string {
   const lines: string[] = [];
 
   // Use the existing cooldown report formatter
@@ -175,6 +178,17 @@ export function formatCooldownSessionResult(result: CooldownSessionResult): stri
     for (const s of result.runSummaries) {
       lines.push(formatRunSummaryLine(s));
     }
+    lines.push('');
+  }
+
+  // Rule suggestions review section
+  if (suggestionReview) {
+    lines.push('--- Rule Suggestions ---');
+    lines.push(`  Accepted: ${suggestionReview.accepted}, Rejected: ${suggestionReview.rejected}, Deferred: ${suggestionReview.deferred}`);
+    lines.push('');
+  } else if (result.ruleSuggestions && result.ruleSuggestions.length > 0) {
+    lines.push('--- Rule Suggestions ---');
+    lines.push(`  ${result.ruleSuggestions.length} pending suggestion(s) (run interactively to review)`);
     lines.push('');
   }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -13,6 +13,7 @@ import { registerDecisionCommands } from './commands/decision.js';
 import { registerRunCommands } from './commands/run.js';
 import { registerApproveCommand } from './commands/approve.js';
 import { registerGateCommands } from './commands/gate.js';
+import { registerRuleCommands } from './commands/rules.js';
 
 const VERSION = '0.1.0';
 
@@ -49,6 +50,7 @@ export function createProgram(): Command {
   registerRunCommands(program);
   registerApproveCommand(program);
   registerGateCommands(program);
+  registerRuleCommands(program);
 
   return program;
 }

--- a/src/features/cycle-management/types.ts
+++ b/src/features/cycle-management/types.ts
@@ -1,4 +1,13 @@
 /**
+ * Review record for a single rule suggestion during cooldown.
+ */
+export interface SuggestionReviewRecord {
+  id: string;
+  decision: 'accepted' | 'rejected' | 'deferred';
+  rejectionReason?: string;
+}
+
+/**
  * Summary of a single run's execution data for cooldown analysis.
  * Loaded from .kata/runs/<run-id>/ state files by CooldownSession.loadRunSummaries().
  * Shared between CooldownSession (which loads it) and ProposalGenerator (which consumes it).

--- a/src/features/execute/kiai-runner.ts
+++ b/src/features/execute/kiai-runner.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 
 import type { StageCategory, Stage } from '@domain/types/stage.js';
 import type { IFlavorRegistry } from '@domain/ports/flavor-registry.js';
 import type { IDecisionRegistry } from '@domain/ports/decision-registry.js';
+import type { IStageRuleRegistry } from '@domain/ports/rule-registry.js';
 import type {
   IFlavorExecutor,
   OrchestratorContext,
@@ -21,6 +22,8 @@ export interface KiaiRunnerDeps {
   executor: IFlavorExecutor;
   kataDir: string;
   analytics?: UsageAnalytics;
+  /** Optional rule registry passed to the stage orchestrator for rule-driven selection. */
+  ruleRegistry?: IStageRuleRegistry;
 }
 
 export interface KiaiRunOptions {
@@ -87,6 +90,7 @@ export class KiaiRunner {
         flavorRegistry: this.deps.flavorRegistry,
         decisionRegistry: this.deps.decisionRegistry,
         executor: this.deps.executor,
+        ruleRegistry: this.deps.ruleRegistry,
       },
       stage.orchestrator,
     );
@@ -136,6 +140,7 @@ export class KiaiRunner {
       flavorRegistry: this.deps.flavorRegistry,
       decisionRegistry: this.deps.decisionRegistry,
       executor: this.deps.executor,
+      ruleRegistry: this.deps.ruleRegistry,
     });
 
     const result = await metaOrchestrator.runPipeline(categories, options.bet);


### PR DESCRIPTION
## Summary

- **V1 (B1+B2)**: Wire `ruleRegistry?: IStageRuleRegistry` into `KiaiRunnerDeps` (`runStage` + `runPipeline`) and `CooldownSessionDeps`; `CooldownSession.run()` calls `getPendingSuggestions()` wrapped in try/catch (non-critical) and returns `ruleSuggestions?` in result
- **V2 (B3+R11)**: Interactive accept/reject/defer review loop in `kata cooldown` CLI with `--auto-accept-suggestions` headless flag
- **V3 (B4)**: Call `ruleRegistry.acceptSuggestion(id)` / `rejectSuggestion(id, reason)` per decision; deferred leaves suggestion as `pending` on disk
- **V4 (B5)**: `formatCooldownSessionResult()` — new Rule Suggestions section (shows counts if reviewed, pending hint if not); `--json` includes `ruleSuggestions` + `suggestionReview`
- **V8 (B10/R10)**: New `kata rule accept <id>` and `kata rule reject <id> --reason <reason>` commands in `src/cli/commands/rules.ts`; registered in `program.ts`

## Test plan

- [x] `cooldown-session.test.ts` — 4 new tests: includes pending suggestions, empty array, backward compat, only pending status
- [x] `rules.test.ts` — 7 new tests: accept happy path, accept `--json`, accept nonexistent ID error, reject happy path, reject `--json`, reject missing `--reason` throws, reject nonexistent ID error
- [x] `kiai-runner.test.ts` — ruleRegistry smoke test + `runPipeline` passes `ruleRegistry` to `MetaOrchestrator` test
- [x] `cycle-formatter.test.ts` — 4 new tests for Rule Suggestions branches
- [x] `cycle.test.ts` — 2 new `--auto-accept-suggestions` tests
- [x] 1591 tests, 83 test files — typecheck + lint clean

Closes #133 (Wave C Session 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)