### PR TITLE
fix: correct CLI syntax in formatAgentContext() (#235)

### DIFF
--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -147,9 +147,14 @@ describe('SessionExecutionBridge', () => {
       expect(context).toContain(`- **Bet ID**: ${prepared.betId}`);
       expect(context).toContain(`- **Kata dir**: ${kataDir}`);
       expect(context).toContain('### Record as you work');
-      expect(context).toContain(`kata kansatsu record --run-id ${prepared.runId}`);
-      expect(context).toContain(`kata maki record --run-id ${prepared.runId}`);
-      expect(context).toContain(`kata kime record --run-id ${prepared.runId}`);
+      // kansatsu: positional type + content, --run flag (not --run-id)
+      expect(context).toContain(`kata kansatsu record <type> "..." --run ${prepared.runId}`);
+      // valid types listed in context comment
+      expect(context).toContain('decision | prediction | friction | gap | outcome | assumption | insight');
+      // maki: positional name + path, --run flag
+      expect(context).toContain(`kata maki record <name> <path> --run ${prepared.runId}`);
+      // kime: named flags only, --run flag (not --run-id)
+      expect(context).toContain(`kata kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
       expect(context).toContain("### When you're done");
       expect(context).toContain('Do NOT close the run yourself');
     });

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -160,9 +160,10 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
     lines.push('### Record as you work');
     lines.push('Use these commands at natural checkpoints (not after every line of code):');
     lines.push('');
-    lines.push(`  kata kansatsu record --run-id ${prepared.runId} --note "..." --severity info`);
-    lines.push(`  kata maki record --run-id ${prepared.runId} --name "..." --path "..."`);
-    lines.push(`  kata kime record --run-id ${prepared.runId} --decision "..." --rationale "..."`);
+    lines.push('  # kansatsu record — type is one of: decision | prediction | friction | gap | outcome | assumption | insight');
+    lines.push(`  kata kansatsu record <type> "..." --run ${prepared.runId} --severity info`);
+    lines.push(`  kata maki record <name> <path> --run ${prepared.runId}`);
+    lines.push(`  kata kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
     lines.push('');
 
     // Injected learnings


### PR DESCRIPTION
## Summary

- `formatAgentContext()` in `SessionExecutionBridge` was generating wrong CLI syntax that caused agents to fail immediately on first instrumentation attempt with `error: required option '--run <id>' not specified`
- Fixes `--run-id` → `--run` across all three recording commands (kansatsu, maki, kime)
- Adds positional arguments for `kansatsu record <type> <content>` and `maki record <name> <path>` which are required by their respective CLI handlers
- Adds an inline comment listing the valid kansatsu record types (`decision | prediction | friction | gap | outcome | assumption | insight`) so agents know what to pass

## What changed

**`src/infrastructure/execution/session-bridge.ts`** — `formatAgentContext()` method:

Before:
```
kata kansatsu record --run-id <id> --note "..." --severity info
kata maki record --run-id <id> --name "..." --path "..."
kata kime record --run-id <id> --decision "..." --rationale "..."
```

After:
```
# kansatsu record — type is one of: decision | prediction | friction | gap | outcome | assumption | insight
kata kansatsu record <type> "..." --run <id> --severity info
kata maki record <name> <path> --run <id>
kata kime record --decision "..." --rationale "..." --run <id>
```

**`src/infrastructure/execution/session-bridge.test.ts`** — updated `formatAgentContext()` test assertions to assert the correct syntax and that valid type list appears in the output.

## Test plan

- [x] `npx vitest run src/infrastructure/execution/session-bridge.test.ts` — 26 tests pass
- [x] `npm run typecheck` — no type errors

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal command syntax and parameter handling for improved consistency.
* **Tests**
  * Updated test assertions to reflect revised command formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->