### PR TITLE
fix: write run.json in prepare() so kata watch discovers bridge runs (#234)

### DIFF
--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { SessionExecutionBridge } from './session-bridge.js';
 import type { AgentCompletionResult } from '@domain/ports/session-bridge.js';
 import { CycleSchema } from '@domain/types/cycle.js';
+import { RunSchema } from '@domain/types/run-state.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -131,6 +132,105 @@ describe('SessionExecutionBridge', () => {
 
       expect(prepared.stages).toEqual(['research']);
       expect(prepared.isolation).toBe('shared'); // no build stage → shared
+    });
+
+    it('should write run.json to runs/<run-id>/run.json (#234)', () => {
+      const cycle = createCycle(kataDir);
+      const betId = cycle.bets[0]!.id;
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepare(betId);
+
+      const runJsonPath = join(kataDir, 'runs', prepared.runId, 'run.json');
+      expect(existsSync(runJsonPath)).toBe(true);
+
+      const raw = JSON.parse(readFileSync(runJsonPath, 'utf-8'));
+      // Must parse against RunSchema without throwing
+      const run = RunSchema.parse(raw);
+      expect(run.id).toBe(prepared.runId);
+      expect(run.betId).toBe(betId);
+      expect(run.cycleId).toBe(cycle.id);
+      expect(run.betPrompt).toBe('Fix the login bug');
+      expect(run.stageSequence).toEqual(['research', 'plan', 'build', 'review']);
+      expect(run.currentStage).toBe('research');
+    });
+
+    it('run.json status should be "running", not "in-progress" (#234)', () => {
+      const cycle = createCycle(kataDir);
+      const betId = cycle.bets[0]!.id;
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepare(betId);
+
+      const runJsonPath = join(kataDir, 'runs', prepared.runId, 'run.json');
+      const raw = JSON.parse(readFileSync(runJsonPath, 'utf-8'));
+      expect(raw.status).toBe('running');
+    });
+
+    it('run.json stageSequence should reflect ad-hoc stages (#234)', () => {
+      const betId = randomUUID();
+      createCycle(kataDir, {
+        bets: [{
+          id: betId,
+          description: 'Research-only bet',
+          appetite: 15,
+          outcome: 'pending',
+          kata: { type: 'ad-hoc', stages: ['research'] },
+        }],
+      });
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepare(betId);
+
+      const runJsonPath = join(kataDir, 'runs', prepared.runId, 'run.json');
+      const run = RunSchema.parse(JSON.parse(readFileSync(runJsonPath, 'utf-8')));
+      expect(run.stageSequence).toEqual(['research']);
+      expect(run.currentStage).toBe('research');
+    });
+
+    it('run.json should be discoverable by listActiveRuns (#234)', () => {
+      // Simulate what kata watch does: list run directories, read run.json,
+      // filter by status === "running". Bridge-prepared runs must be visible.
+      const cycle = createCycle(kataDir);
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      bridge.prepareCycle(cycle.id);
+
+      const runsDir = join(kataDir, 'runs');
+      const runDirs = readdirSync(runsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+
+      expect(runDirs.length).toBe(2); // one per bet
+
+      const activeRuns = runDirs.filter((runId) => {
+        const runJsonPath = join(runsDir, runId, 'run.json');
+        if (!existsSync(runJsonPath)) return false;
+        try {
+          const run = RunSchema.parse(JSON.parse(readFileSync(runJsonPath, 'utf-8')));
+          return run.status === 'running';
+        } catch {
+          return false;
+        }
+      });
+
+      expect(activeRuns.length).toBe(2);
+    });
+
+    it('run.json stage directories should be created for each stage (#234)', () => {
+      const cycle = createCycle(kataDir);
+      const betId = cycle.bets[0]!.id;
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepare(betId);
+
+      // createRunTree creates stage directories with state.json files
+      const stagesDir = join(kataDir, 'runs', prepared.runId, 'stages');
+      expect(existsSync(stagesDir)).toBe(true);
+      for (const stage of ['research', 'plan', 'build', 'review']) {
+        const stateJson = join(stagesDir, stage, 'state.json');
+        expect(existsSync(stateJson)).toBe(true);
+      }
     });
   });
 

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -14,8 +14,10 @@ import type { ExecutionManifest } from '@domain/types/manifest.js';
 import { ExecutionHistoryEntrySchema } from '@domain/types/history.js';
 import { CycleSchema, type Cycle } from '@domain/types/cycle.js';
 import { type Bet } from '@domain/types/bet.js';
+import { StageCategorySchema } from '@domain/types/stage.js';
 import { z } from 'zod/v4';
 import { JsonStore } from '@infra/persistence/json-store.js';
+import { createRunTree } from '@infra/persistence/run-store.js';
 import { KATA_DIRS } from '@shared/constants/paths.js';
 import { logger } from '@shared/lib/logger.js';
 
@@ -100,6 +102,12 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
       startedAt,
       status: 'in-progress',
     });
+
+    // Write run.json to runs/<run-id>/run.json so kata watch can discover
+    // this run. BridgeRunMeta uses status "in-progress" but RunSchema requires
+    // "running" — we map on write. Only valid StageCategory values are written
+    // (filter guards against hypothetical custom stage strings).
+    this.writeRunJson(runId, bet.id, bet.description, cycle.id, stages, startedAt);
 
     return prepared;
   }
@@ -526,6 +534,63 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
       JsonStore.write(cyclePath, cycle, CycleSchema);
     } catch (err) {
       logger.warn(`Failed to update bet outcome in cycle "${cycleId}" for bet "${betId}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // ── run.json writer ───────────────────────────────────────────────────
+
+  /**
+   * Write a RunSchema-conforming run.json to runs/<runId>/run.json.
+   *
+   * This is called by prepare() so that kata watch (which reads RunSchema)
+   * can discover bridge-prepared runs immediately (#234).
+   *
+   * Status mapping: BridgeRunMeta uses "in-progress" but RunSchema uses
+   * "running". We always write "running" here. The run.json is NOT updated
+   * when the bridge run completes — history entries are the completion record.
+   *
+   * Stage filtering: RunSchema.stageSequence requires StageCategory values.
+   * Any stage string that is not a valid StageCategory is dropped so that
+   * Zod validation does not fail on hypothetical custom stage names.
+   */
+  private writeRunJson(
+    runId: string,
+    betId: string,
+    betPrompt: string,
+    cycleId: string,
+    stages: string[],
+    startedAt: string,
+  ): void {
+    try {
+      const validCategories = StageCategorySchema.options;
+      const stageSequence = stages.filter((s): s is typeof validCategories[number] =>
+        (validCategories as readonly string[]).includes(s),
+      );
+
+      // Fall back to the standard four-stage sequence if all were filtered out
+      const finalSequence = stageSequence.length > 0
+        ? stageSequence
+        : (['research', 'plan', 'build', 'review'] as const);
+
+      const runsDir = join(this.kataDir, KATA_DIRS.runs);
+      createRunTree(runsDir, {
+        id: runId,
+        cycleId,
+        betId,
+        betPrompt,
+        stageSequence: [...finalSequence],
+        currentStage: finalSequence[0] ?? null,
+        status: 'running',
+        startedAt,
+      });
+    } catch (err) {
+      // Non-critical: log a warning but do not abort prepare(). The bridge-run
+      // metadata was already written and the agent can still execute. kata watch
+      // will simply not see this run until the issue is resolved.
+      logger.warn('Failed to write run.json for bridge run — kata watch will not see this run.', {
+        runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- `SessionExecutionBridge.prepare()` now writes `runs/<run-id>/run.json` (via `createRunTree`) in addition to `bridge-runs/<run-id>.json`
- `kata watch` (via `run-reader.ts`) reads `RunSchema` from `runs/<run-id>/run.json` — previously it skipped every bridge-prepared run with a \"File not found\" warning and showed \"0 active runs\"
- Status enum mismatch resolved: `BridgeRunMeta` uses `\"in-progress\"`, `RunSchema` uses `\"running\"` — the run.json always gets `\"running\"`
- Stage filtering: stages array is filtered to valid `StageCategory` values before writing; falls back to the standard four-stage sequence if all are filtered out
- The write is wrapped in a try/catch and is non-critical — on failure a warning is logged and `prepare()` still returns the `PreparedRun` so agents can execute uninterrupted
- 5 new tests added covering: run.json existence and schema validity, status mapping, ad-hoc stage reflection, `listActiveRuns`-style discovery, and stage directory creation

## Files changed

- `src/infrastructure/execution/session-bridge.ts` — new `writeRunJson()` private method, called from `prepare()` after `writeBridgeRunMeta()`; imports `StageCategorySchema` and `createRunTree`
- `src/infrastructure/execution/session-bridge.test.ts` — 5 new tests in the `prepare()` describe block, imports `RunSchema`

## Test plan

- [x] `npx vitest run src/infrastructure/execution/session-bridge.test.ts` — 31 tests pass (was 26)
- [x] `npm run typecheck` — clean
- [ ] Manual: `kata kiai cycle <id> --prepare` then check `.kata/runs/<run-id>/run.json` exists and `kata watch` shows the run as active

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved run discoverability and status tracking through persistent run manifests.
  * Enhanced ad-hoc stage handling with proper state management.

* **Tests**
  * Added comprehensive test coverage for run creation, status semantics, stage handling, and run discovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->