### PR TITLE
fix: suppress stale history validation warnings in cooldown (#238)

### DIFF
--- a/src/cli/commands/learning-review.ts
+++ b/src/cli/commands/learning-review.ts
@@ -29,9 +29,9 @@ export function registerLearningReviewCommand(knowledge: Command): void {
     .action(withCommandContext(async (ctx) => {
       const localOpts = ctx.cmd.opts();
 
-      // Load execution history
+      // Load execution history — suppress warnings for legacy pre-schema files (#238)
       const historyDir = kataDirPath(ctx.kataDir, 'history');
-      const history = JsonStore.list(historyDir, ExecutionHistoryEntrySchema);
+      const history = JsonStore.list(historyDir, ExecutionHistoryEntrySchema, { warnOnInvalid: false });
 
       if (history.length === 0) {
         console.log('No execution history found. Run some flows first to generate patterns.');

--- a/src/domain/ports/persistence.ts
+++ b/src/domain/ports/persistence.ts
@@ -14,6 +14,14 @@ export interface IPersistence {
   read<T>(filePath: string, schema: z.ZodType<T>): T;
   write<T>(filePath: string, data: T, schema: z.ZodType<T>): void;
   exists(filePath: string): boolean;
-  list<T>(dirPath: string, schema: z.ZodType<T>): T[];
+  /**
+   * List all entries in a directory, validating each against schema.
+   * Invalid entries are skipped.
+   *
+   * @param options.warnOnInvalid - When false, downgrades validation-failure
+   *   log messages from `warn` to `debug`. Use for directories that may
+   *   contain legacy/pre-schema files. Defaults to `true`.
+   */
+  list<T>(dirPath: string, schema: z.ZodType<T>, options?: { warnOnInvalid?: boolean }): T[];
   ensureDir(dirPath: string): void;
 }

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -881,9 +881,19 @@ export class CooldownSession {
 
   /**
    * Load execution history entries associated with this cycle.
+   *
+   * Uses warnOnInvalid: false to suppress validation warnings for legacy
+   * pre-schema history files that predate required fields (pipelineId,
+   * stageType, stageIndex, adapter, startedAt, completedAt). These files
+   * are expected to exist in long-running projects and are silently skipped
+   * rather than flooding cooldown output with noise. See issue #238.
    */
   private loadCycleHistory(cycleId: string): ExecutionHistoryEntry[] {
-    const allEntries = this.deps.persistence.list(this.deps.historyDir, ExecutionHistoryEntrySchema);
+    const allEntries = this.deps.persistence.list(
+      this.deps.historyDir,
+      ExecutionHistoryEntrySchema,
+      { warnOnInvalid: false },
+    );
     return allEntries.filter((entry) => entry.cycleId === cycleId);
   }
 

--- a/src/features/pipeline-run/result-capturer.ts
+++ b/src/features/pipeline-run/result-capturer.ts
@@ -66,8 +66,11 @@ export class ResultCapturer {
 
   /**
    * Get all history entries.
+   *
+   * Uses warnOnInvalid: false to suppress validation warnings for legacy
+   * pre-schema history files in .kata/history/. See issue #238.
    */
   listAll(): ExecutionHistoryEntry[] {
-    return JsonStore.list(this.historyDir, ExecutionHistoryEntrySchema);
+    return JsonStore.list(this.historyDir, ExecutionHistoryEntrySchema, { warnOnInvalid: false });
   }
 }

--- a/src/infrastructure/persistence/json-store.test.ts
+++ b/src/infrastructure/persistence/json-store.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { z } from 'zod/v4';
 import { JsonStore, JsonStoreError } from './json-store.js';
+import { logger } from '@shared/lib/logger.js';
 
 const TestSchema = z.object({
   id: z.string().uuid(),
@@ -153,6 +154,62 @@ describe('JsonStore.list', () => {
 
     const results = JsonStore.list(dir, TestSchema);
     expect(results).toHaveLength(1);
+  });
+
+  it('logs warn by default when a file fails validation', () => {
+    const dir = join(tempDir, 'warn-default');
+    JsonStore.ensureDir(dir);
+    writeFileSync(join(dir, 'bad.json'), JSON.stringify({ id: 'not-uuid', name: '' }));
+
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const debugSpy = vi.spyOn(logger, 'debug');
+
+    JsonStore.list(dir, TestSchema);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]![0]).toContain('Skipping invalid file');
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('logs debug instead of warn when warnOnInvalid is false', () => {
+    const dir = join(tempDir, 'silent-invalid');
+    JsonStore.ensureDir(dir);
+    writeFileSync(join(dir, 'bad.json'), JSON.stringify({ id: 'not-uuid', name: '' }));
+
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const debugSpy = vi.spyOn(logger, 'debug');
+
+    const results = JsonStore.list(dir, TestSchema, { warnOnInvalid: false });
+
+    expect(results).toHaveLength(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledOnce();
+    expect(debugSpy.mock.calls[0]![0]).toContain('Skipping invalid file');
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('still returns valid files when warnOnInvalid is false', () => {
+    const dir = join(tempDir, 'silent-mixed');
+    JsonStore.ensureDir(dir);
+
+    const id = crypto.randomUUID();
+    writeFileSync(join(dir, 'good.json'), JSON.stringify({ id, name: 'valid' }));
+    writeFileSync(join(dir, 'bad.json'), JSON.stringify({ id: 'not-uuid', name: '' }));
+    writeFileSync(join(dir, 'legacy.json'), JSON.stringify({ oldField: 'legacy-data' }));
+
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const results = JsonStore.list(dir, TestSchema, { warnOnInvalid: false });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.name).toBe('valid');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 
   it('throws JsonStoreError when directory is not readable (EACCES)', () => {

--- a/src/infrastructure/persistence/json-store.ts
+++ b/src/infrastructure/persistence/json-store.ts
@@ -84,12 +84,19 @@ export const JsonStore = {
 
   /**
    * Read all .json files in a directory and validate each against schema.
-   * Skips files that fail validation (logs warning).
+   * Skips files that fail validation.
+   *
+   * @param options.warnOnInvalid - When false, downgrades validation-failure
+   *   log messages from `warn` to `debug`. Use this for directories that may
+   *   contain legacy/pre-schema files (e.g. `.kata/history/`) where stale files
+   *   are expected and noise-free output is preferred. Defaults to `true`.
    */
-  list<T>(dir: string, schema: z.ZodType<T>): T[] {
+  list<T>(dir: string, schema: z.ZodType<T>, options?: { warnOnInvalid?: boolean }): T[] {
     if (!existsSync(dir)) {
       return [];
     }
+
+    const warnOnInvalid = options?.warnOnInvalid ?? true;
 
     let files: string[];
     try {
@@ -104,11 +111,16 @@ export const JsonStore = {
       try {
         results.push(JsonStore.read(join(dir, file), schema));
       } catch (err) {
-        logger.warn(`Skipping invalid file "${file}" in ${dir}`, {
+        const logData = {
           file,
           dir,
           error: err instanceof Error ? err.message : String(err),
-        });
+        };
+        if (warnOnInvalid) {
+          logger.warn(`Skipping invalid file "${file}" in ${dir}`, logData);
+        } else {
+          logger.debug(`Skipping invalid file "${file}" in ${dir}`, logData);
+        }
       }
     }
 

--- a/src/infrastructure/persistence/memory-persistence.ts
+++ b/src/infrastructure/persistence/memory-persistence.ts
@@ -36,7 +36,8 @@ export class MemoryPersistence implements IPersistence {
     return this.store.has(filePath);
   }
 
-  list<T>(dirPath: string, schema: z.ZodType<T>): T[] {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  list<T>(dirPath: string, schema: z.ZodType<T>, _options?: { warnOnInvalid?: boolean }): T[] {
     const prefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
     const results: T[] = [];
     for (const [key, value] of this.store) {


### PR DESCRIPTION
## Summary

- Adds `warnOnInvalid?: boolean` option to `JsonStore.list()` and `IPersistence.list()` — when `false`, validation-failure log messages are downgraded from `warn` to `debug`
- Passes `{ warnOnInvalid: false }` from all history-loading call sites: `CooldownSession.loadCycleHistory()`, `ResultCapturer.listAll()`, and `learning-review` CLI command
- Updates `MemoryPersistence.list()` to accept (and ignore) the option to stay in sync with the interface

## Problem

Every `kata cooldown` invocation emitted 10+ `[warn] Skipping invalid file` messages from old pre-schema history files in `.kata/history/`. These files were written before required fields (`pipelineId`, `stageType`, `stageIndex`, `adapter`, `startedAt`, `completedAt`) were added to `HistorySchema`. The warnings drowned out real cooldown output (~200 lines of noise before any real content).

## Approach

Added a `warnOnInvalid` option (defaults to `true` — no behavior change for existing call sites) rather than changing the default globally. This preserves warning behavior for all other `JsonStore.list()` usages where unexpected invalid files are a genuine concern (cycles, learnings, rules, etc.). Only history-loading paths that are known to contain legacy files get the quiet treatment.

## Test plan

- [x] New tests in `json-store.test.ts` verify: default behavior still logs `warn`, `{ warnOnInvalid: false }` logs `debug` instead, valid files still returned in both modes
- [x] All 2997 tests pass across 147 test files
- [x] `npm run typecheck` passes cleanly
- [x] `kata cooldown` will no longer emit `[warn] Skipping invalid file` for legacy history files

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)