### PR TITLE
docs: add three-space architecture (San-Ma) vision document

### DIFF
--- a/docs-site/vision/three-space.md
+++ b/docs-site/vision/three-space.md
@@ -1,0 +1,1 @@
+../../docs/vision/three-space-architecture.md

--- a/docs/vision/knowledge-graph-vision.md
+++ b/docs/vision/knowledge-graph-vision.md
@@ -1,0 +1,473 @@
+# Knowledge Graph Vision — nanograph Integration
+
+> How Kata's bunkai (knowledge) system evolves from JSON files to a proper graph database, enabling multi-hop reasoning, structural pattern detection, and emergent intelligence across keiko cycles.
+>
+> **Companion documents**:
+> - [Three-Space Architecture Vision](three-space-architecture.md) — **Prerequisite**: directory restructuring that creates the clean `knowledge/` space nanograph indexes
+> - [Meta-Learning Architecture](../meta-learning-architecture.md) — Current observation system, knowledge graph, and self-improvement loop
+> - [v3 Rust Port Vision](v3-rust-port.md) — nanograph carries forward natively into Rust
+> - [Spike: Knowledge Graph](../pipeline/spike-knowledge-graph.md) — Early design exploration on graph implementation options
+> - [Unified Roadmap](../unified-roadmap.md) — Waves F–J build the meta-learning system progressively
+>
+> **Status**: Vision document. nanograph integration happens as a late v1 feature, after three-space architecture is complete. Behind the existing `KnowledgeStore` port interface. No API changes for consumers.
+
+---
+
+## Why a Graph Database
+
+Kata already *is* a graph. The `graph-index.json` is a hand-built edge list. Every UUID cross-reference (learning → observation, run → cycle, bet → learning) is an implicit edge. The hierarchical tier promotion chain (step → flavor → stage → category → agent) is a directed acyclic graph. We're maintaining graph infrastructure by hand in JSON — and it's reaching its limits.
+
+### What JSON can't do
+
+| Query | JSON approach | Difficulty |
+|-------|-------------|-----------|
+| "Why does Kata believe X?" | Load learning, load each citation, load each run | 3+ file reads, manual assembly |
+| "What patterns span multiple keikos?" | Load all learnings, group by category, check cross-cycle citations | Full scan, O(n) |
+| "Which kataka is best calibrated for this domain?" | Load all reflections, filter calibrations, cross-reference runs for domain tags | Multi-file join, manual |
+| "What learnings are losing evidence?" | Load all learnings, compute decay, sort | Full scan + computation |
+| "Show the evidence chain for this strategic learning" | Recursive traversal: learning → citations → observations → runs → cycles | Manual BFS across files |
+
+These are the queries that make Kata's intelligence loop actually intelligent. Today, each requires custom code in `KnowledgeStore`, `CooldownSession`, or `ProposalGenerator`. A graph database makes them declarative.
+
+### Why nanograph specifically
+
+| Requirement | nanograph capability |
+|-------------|---------------------|
+| On-device (no external service) | Embedded, single-process |
+| Schema-as-code | TypeScript/Rust type definitions |
+| Rich query language | nanoQL (Datalog + GraphQL syntax) |
+| Multi-modal search | 6 modes: BM25, vector, fuzzy, phrase, hybrid RRF, exact |
+| Change data capture | CDC for reactive updates |
+| Rust-native | No FFI boundary in v3 |
+| TypeScript SDK | `nanograph-db` npm package for v2 |
+
+---
+
+## Design Principles
+
+These principles are informed by graph theory, cognitive science research on knowledge systems, and practical experience with structured agent knowledge.
+
+### 1. Typed, reasoned edges over embedding similarity
+
+Every edge in the graph carries a semantic type that agents can evaluate. Two learnings connected by `contradicts` mean something fundamentally different than two connected by `refines`. Embedding-based similarity (vector search) is useful for *discovery* — finding candidate connections — but discovered connections should be promoted into typed edges with explicit reasons.
+
+**Principle**: Vector search finds candidates. Typed edges encode decisions. The graph's value is in its curated topology, not in algorithmic adjacency.
+
+### 2. Three-space node taxonomy
+
+Nodes belong to one of three spaces with different durability, growth patterns, and query characteristics:
+
+| Space | Content | Durability | Growth | Query pattern |
+|-------|---------|-----------|--------|---------------|
+| **Knowledge** | Learnings, patterns, topics, insights | Permanent (versioned, soft-delete) | Steady, compounds | Multi-hop traversal, aggregation |
+| **Identity** | Kataka, steps, flavors, methodology | Persistent, evolves slowly | Tens of nodes | Full load at session start |
+| **Execution** | Runs, observations, decisions, artifacts | Temporal, flows through | Fluctuating, high volume | Targeted lookup, time-range queries |
+
+Content moves from Execution → Knowledge (promotion) but never backward. This separation prevents conflating temporal operational state with durable knowledge — a failure mode that degrades both.
+
+### 3. Forgetting is a first-class operation
+
+Accumulation without pruning degrades signal-to-noise ratio. The graph needs active lifecycle management:
+
+- **Confidence decay**: Learnings lose confidence over time without reinforcement (already implemented: operational 50%/30d, strategic 20%/90d, constitutional 0%)
+- **Supersession**: New learnings can explicitly override older ones via `supersedes` edges
+- **Archival**: Learnings below confidence threshold are archived (soft-deleted, never hard-deleted — provenance preserved)
+- **Condition-based triggers**: Maintenance fires on state thresholds, not schedules (e.g., "stale learnings exceed 20%" rather than "weekly review")
+
+### 4. Value lives in topology
+
+The graph's intelligence is in its shape — the paths between nodes, the density of connections, the clusters that form. Structural signals that only exist in the graph:
+
+| Signal | Detection | Meaning |
+|--------|-----------|---------|
+| High citation density | count(cited_by edges) on a learning | Well-evidenced, high confidence |
+| Tension cluster | Multiple `contradicts` edges within a topic | Unresolved conflict requiring resolution |
+| Agent breadth | count(distinct topics) via kataka → attributed_to → belongs_to | Agent specialization vs generalization |
+| Learning velocity | count(promoted_from edges) per cycle | Are we learning from execution? |
+| Orphan nodes | Knowledge nodes with degree 0 | Disconnected knowledge needing pruning or connection |
+| Evidence chains | Multi-hop path: Learning ← citation ← Observation ← Run ← Cycle | Full provenance for any belief |
+
+### 5. Progressive disclosure via graph structure
+
+Agents shouldn't load all learnings at once. The graph enables layered loading:
+
+1. **Load topic clusters** — see what knowledge domains exist
+2. **Load topic descriptions** — understand what each area covers without reading individual learnings
+3. **Load relevant learnings** — only the ones matching the current stage/domain
+4. **Traverse for context** — follow edges to evidence, contradictions, related topics
+
+This mirrors how hierarchical navigation works in structured knowledge systems — attention management through progressive narrowing.
+
+---
+
+## Graph Schema
+
+### Edge Type Design
+
+Edges fall into two categories based on a simple rule: **edge types should encode meaning that node types can't.**
+
+**Structural edges** (containment/hierarchy) — the relationship is implied by the node types. A Run connected to a Bet via `part_of` is unambiguous because they're different node types. One general edge suffices.
+
+**Semantic edges** (knowledge relationships) — the meaning differs between nodes of the same type. Two Learnings can be connected in multiple ways that mean fundamentally different things. Each needs its own edge type.
+
+### Node Types
+
+#### Knowledge Space (durable, compounds)
+
+```
+Learning {
+  id: UUID
+  content: string                // The knowledge claim
+  description?: string           // ~150 chars beyond content (progressive disclosure)
+  confidence: 0-1                // Evidence-based, with decay
+  permanence: operational | strategic | constitutional
+  tier: step | flavor | stage | category | agent
+  category: string
+  source: extracted | synthesized | imported | user
+  versions: Version[]            // Full mutation history
+  usageCount: number             // Times injected into agent prompts
+  lastUsedAt?: ISO
+  refreshBy?: ISO
+  expiresAt?: ISO
+  archived: boolean
+  createdAt: ISO
+  updatedAt: ISO
+}
+
+Topic {
+  id: UUID
+  name: string                   // e.g., "execution-orchestration"
+  description: string            // What this knowledge area covers
+  level: hub | domain | topic    // Navigational hierarchy
+  tensions?: string[]            // Unresolved conflicts within this area
+  openQuestions?: string[]       // Unexplored directions
+  createdAt: ISO
+}
+```
+
+#### Identity Space (persistent, evolves slowly)
+
+```
+Kataka {
+  id: UUID
+  name: string
+  role: observer | executor | synthesizer | reviewer
+  skills: string[]
+  methodology?: string           // How this agent works
+  calibration?: CalibrationScore[]  // Prediction accuracy by domain
+  active: boolean
+  createdAt: ISO
+}
+
+Step    { id, type, description, artifacts, learningHooks }
+Flavor  { id, name, stageCategory, steps[], isolation }
+```
+
+#### Execution Space (temporal, flows through)
+
+```
+Run         { id, cycleId, betId, katakaId, status, domainTags, startedAt, completedAt }
+Observation { id, type, content, severity?, taxonomy?, katakaId, timestamp }
+Decision    { id, decisionType, selection, reasoning, confidence, outcome?, decidedAt }
+Reflection  { id, type, insight?, correct?, path?, sourceObservationIds, timestamp }
+Cycle       { id, name, state, budget, createdAt }
+Bet         { id, description, appetite, outcome, domainTags }
+Artifact    { id, name, path, summary, type, producedAt }
+```
+
+### Edge Types
+
+```
+STRUCTURAL (general, inferred from node types)
+──────────────────────────────────────────────
+part_of         Run → Bet, Bet → Cycle, Stage → Run
+                Flavor → Stage, Step → Flavor
+                Learning → Topic, Topic → Topic (hierarchy)
+
+produced_in     Artifact → Run
+
+attributed_to   Observation → Kataka, Decision → Kataka
+
+
+SEMANTIC (specific, encode meaning node types can't)
+────────────────────────────────────────────────────
+
+Knowledge edges (between Knowledge Space nodes):
+  cited_by        Learning ← Observation     "This observation is evidence for this learning"
+  reinforced_by   Learning ← Observation     "Later evidence strengthening this learning"
+  derived_from    Learning ← Learning        "Synthesized from parent learning(s)"
+  contradicts     Learning ↔ Learning        "These learnings are in tension"
+  supersedes      Learning → Learning        "This learning replaces the older one"
+  refines         Learning → Learning        "Narrower/more precise version"
+
+Cross-space edges (bridges between spaces):
+  promoted_from   Learning ← Observation     "Execution observation became durable knowledge"
+  validated_by    Learning ← Run             "This learning was tested in this execution"
+  applied_in      Learning → Run             "This learning was injected into context"
+  calibrated_by   Kataka ← Reflection        "Calibration data from this reflection"
+  proposed_from   Bet ← Learning/Observation "Next-cycle proposal sourced from this"
+```
+
+### Why this edge set is minimal
+
+- **4 structural edges** handle all containment (vs. 10+ if every pair got its own name)
+- **6 semantic knowledge edges** encode the relationships that matter for reasoning about learnings
+- **5 cross-space edges** bridge execution to knowledge to identity — where emergent value lives
+
+Total: **15 edge types**. Each carries a distinct meaning that can't be inferred from node types alone. Adding more would be premature — let usage reveal what's missing.
+
+---
+
+## Key Query Patterns
+
+These are the queries that justify a graph database. Each is impractical with flat JSON files but natural with nanoQL.
+
+### Provenance
+
+```
+"Why does Kata believe TDD reduces rework?"
+
+Learning{content: ~"TDD*rework"}
+  ← cited_by ← Observation
+  ← part_of ← Run
+  ← part_of ← Bet
+  ← part_of ← Cycle
+
+→ "Based on 6 observations across 3 runs in Keiko 4 and 5"
+```
+
+### Cross-cycle pattern detection
+
+```
+"What patterns appear in 3+ keikos?"
+
+Learning
+  ← cited_by ← Observation
+  ← part_of ← Run
+  ← part_of ← Bet
+  ← part_of ← Cycle
+
+GROUP BY Learning.id
+HAVING count(DISTINCT Cycle.id) >= 3
+
+→ Learnings with evidence spanning multiple cycles
+```
+
+### Tension detection
+
+```
+"What unresolved contradictions exist?"
+
+Learning -[contradicts]- Learning
+WHERE both.archived = false
+AND NOT EXISTS(Learning -[supersedes]-> either)
+
+→ Active contradictions needing resolution
+```
+
+### Agent calibration
+
+```
+"Which kataka is best for this domain?"
+
+Kataka ← calibrated_by ← Reflection{type: calibration}
+WHERE Reflection.domain = $domain
+ORDER BY Reflection.accuracyRate DESC
+
+→ Ranked agents by prediction accuracy in domain
+```
+
+### Knowledge health
+
+```
+"What learnings are going stale?"
+
+Learning
+WHERE decayedConfidence(Learning) < 0.3
+AND Learning.archived = false
+AND Learning.permanence != 'constitutional'
+
+→ Candidates for review, reinforcement, or archival
+```
+
+### Topic navigation (progressive disclosure)
+
+```
+"What should I load for build stage context?"
+
+Topic{level: hub}
+  → part_of → Topic{level: domain, relevant to 'build'}
+    → part_of → Topic{level: topic}
+      → part_of → Learning{tier: stage, confidence > 0.5}
+
+→ Layered context: hub → domains → topics → learnings
+```
+
+---
+
+## Topic Clusters — Navigational Structure
+
+Topics provide the progressive disclosure layer, replacing flat category strings with a navigable hierarchy:
+
+```
+Hub: "kata-methodology"
+├── Domain: "execution-orchestration"
+│   ├── Topic: "gate-evaluation"
+│   │   ├── Learning: "predecessor gates prevent premature execution"
+│   │   ├── Learning: "human-approved gates need timeout handling"
+│   │   └── Learning: "gate failures correlate with missing artifacts"
+│   └── Topic: "adapter-selection"
+│       ├── Learning: "claude-cli adapter needs context size limits"
+│       └── Learning: "manual adapter works for exploratory stages"
+├── Domain: "knowledge-management"
+│   ├── Topic: "confidence-scoring"
+│   ├── Topic: "tier-promotion"
+│   └── Topic: "decay-and-pruning"
+└── Domain: "agent-attribution"
+    ├── Topic: "kataka-calibration"
+    └── Topic: "cross-agent-patterns"
+```
+
+Topics are **auto-generated from learning categories** during migration (Phase 1), then curated over time. The hierarchy doesn't need to be deep — 3 levels (hub → domain → topic) is sufficient for attention management.
+
+---
+
+## Learning Lifecycle
+
+```
+                    ┌──────────┐
+                    │  active   │ ← Created from observation or synthesis
+                    └─────┬────┘
+                          │
+              ┌───────────┼───────────┐
+              ▼           ▼           ▼
+        reinforced    unchanged    contradicted
+        (confidence   (confidence  (friction
+         increases)    decays)     detected)
+              │           │           │
+              ▼           ▼           ▼
+         still active   ┌──────┐   ┌──────────┐
+                        │ stale │   │ superseded│
+                        └───┬──┘   └──────────┘
+                            │
+              ┌─────────────┼──────────────┐
+              ▼             ▼              ▼
+         resurrected    ┌────────┐    ┌────────┐
+         (new evidence) │archived│    │ pruned │
+                        └────────┘    └────────┘
+                                    (operational only,
+                                     3+ cycles archived)
+```
+
+### State transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| active | stale | Confidence decays below 0.3 |
+| stale | active | New `reinforced_by` edge added |
+| stale | archived | No reinforcement for 2 cycles + confidence < 0.2 |
+| active | superseded | Another learning creates `supersedes` edge |
+| archived | active | Explicit resurrection via `resurrectedBy()` |
+| archived | pruned | 3+ cycles archived, operational permanence only |
+
+### Condition-based lifecycle triggers
+
+Maintenance fires on state thresholds, not schedules:
+
+| Condition | Fires when | Action |
+|-----------|-----------|--------|
+| Stale ratio > 20% | `count(stale) / count(active) > 0.2` | Suggest pruning session in cooldown |
+| Orphan topics > 5 | Topics with no learning children | Suggest restructuring |
+| Contradiction count > 3 | Active contradicts edges without supersedes resolution | Surface in cooldown for resolution |
+| Unmatched predictions > 10 | Predictions without matching outcomes | Suggest calibration review |
+| Citation density < 2 for strategic | Strategic learnings with fewer than 2 citations | Flag for evidence gathering |
+
+---
+
+## Migration Path
+
+### Pre-integration checklist
+
+Do not begin nanograph integration until all of these are true:
+
+- [ ] **Three-space architecture complete** — `self/`, `knowledge/`, `ops/` separation with knowledge promotion pipeline ([vision doc](three-space-architecture.md))
+- [ ] nanograph `nanograph-db` npm package ≥1.0 (stable TypeScript SDK API)
+- [ ] 10+ real keiko cycles completed (domain model battle-tested)
+- [ ] `KnowledgeStore` port interface stable (no breaking changes for 2+ keikos)
+- [ ] `maybe {}` supported in nanograph runtime (for optional fields)
+
+### Phase 1: Knowledge Space (post-v1)
+
+**Scope**: Replace `.kata/knowledge/` JSON files with nanograph. Consumers (`KnowledgeStore`) see no API change.
+
+- Import existing learnings as Knowledge nodes
+- Import `graph-index.json` edges as typed edges (citation, reinforcement, derivation)
+- Auto-generate Topic nodes from learning `category` fields
+- Create `part_of` edges from learnings to topics
+- Enable nanoQL queries behind `KnowledgeStore.query()`
+- **Fallback**: JSON files remain as export format; nanograph is the primary store
+
+### Phase 2: Execution Space
+
+**Scope**: Observations, decisions, artifacts, reflections become graph nodes.
+
+- Import from JSONL files into nanograph on cycle completion
+- Create `cited_by`, `reinforced_by` edges from learning citations
+- Create `part_of` edges for run → bet → cycle hierarchy
+- Create `attributed_to` edges for kataka attribution
+- Enable cross-space queries (learning provenance, agent calibration)
+
+### Phase 3: Cooldown as graph analysis
+
+**Scope**: `CooldownSession` and `ProposalGenerator` query the graph instead of loading files.
+
+- Cross-cycle pattern detection via multi-hop queries
+- Contradiction detection via `contradicts` edge traversal
+- Tension surfacing via topic-level aggregation
+- Proposal generation from structural signals (orphans, stale clusters, high-tension topics)
+- Learning velocity metrics from `promoted_from` edge counts per cycle
+
+### Phase 4: Agent context from graph
+
+**Scope**: `formatAgentContext()` queries nanograph for progressive disclosure.
+
+- Load topic hub → relevant domains → specific learnings (layered)
+- Include provenance summaries with each learning
+- Surface active contradictions as "open questions"
+- Inject domain confidence from graph-computed metrics
+- Replace flat learning lists with structured knowledge maps
+
+### Phase 5: Visualization and advanced queries
+
+**Scope**: Graph becomes interactive and visible.
+
+- Dojo integration: visualize knowledge graph in training sessions
+- nanoQL REPL via `kata bunkai query` command
+- Graph health dashboard: stale ratio, orphan count, contradiction count, learning velocity
+- Export/import for graph portability
+- CDC-based reactive updates (e.g., new observation → auto-check for learning candidates)
+
+---
+
+## Inspiration and References
+
+This design is informed by several sources:
+
+- **Kata's own spike** ([spike-knowledge-graph.md](../pipeline/spike-knowledge-graph.md)): Query pattern analysis showing 70% of queries are simple filters (JSON-suitable) but 30% need real graph traversal
+- **Graph theory**: Property graph model with typed nodes and edges; progressive disclosure via hierarchical navigation
+- **Cognitive science**: Knowledge decay mirrors synaptic pruning; reinforcement mirrors memory consolidation; three-space separation prevents the conflation failures documented in knowledge management research
+- **Structured knowledge systems**: Wiki-links as curated, reasoned edges; Maps of Content (MOCs) as attention management; the principle that value lives in connections between knowledge, not within individual notes
+- **Agent architecture**: Session-orient patterns for context loading; fresh context per processing phase; condition-based lifecycle triggers over time-based schedules
+
+---
+
+## Non-Goals
+
+- **Replacing the meta-learning architecture.** The observation system, detection engines, synthesis pipeline, and tier promotion all remain. nanograph replaces the *storage and query* layer, not the *processing* logic.
+- **Embedding-only connections.** Vector search is for discovery. The graph stores curated, typed edges. No fog.
+- **External service dependency.** nanograph is embedded, on-device. No cloud, no network dependency.
+- **Premature optimization.** Phase 1 is behind the existing `KnowledgeStore` interface. If nanograph doesn't work out, JSON files are always the fallback.
+
+---
+
+*This is a vision document. It will be refined as v1 matures and real usage reveals which query patterns matter most. The phased approach ensures we can stop at any phase and still have a working system.*

--- a/docs/vision/three-space-architecture.md
+++ b/docs/vision/three-space-architecture.md
@@ -1,0 +1,554 @@
+# Three-Space Architecture Vision — San-Ma (三間)
+
+> How Kata's `.kata/` directory evolves from a flat collection of 22 mixed-purpose subdirectories into a three-space architecture that structurally encodes data durability, enables single-root agent bootstrapping, unlocks cross-run knowledge queries, and prepares the foundation for nanograph integration.
+>
+> **Companion documents**:
+> - [Knowledge Graph Vision — nanograph Integration](knowledge-graph-vision.md) — nanograph depends on three-space separation as a prerequisite
+> - [Meta-Learning Architecture](../meta-learning-architecture.md) — Observation system, knowledge graph, and self-improvement loop
+> - [Spike: Knowledge Graph](../pipeline/spike-knowledge-graph.md) — Early design exploration on graph implementation
+> - [Dogfooding Roadmap](../dogfooding-roadmap.md) — Projects and bet backlog for v1
+>
+> **Status**: Vision document. Three-space separation is a v1 foundational feature that precedes nanograph integration.
+>
+> **Thematic name**: San-Ma (三間) — "three spaces" or "three intervals." In martial arts, *ma* (間) refers to the space between things — the interval that gives structure its meaning.
+
+---
+
+## Why Three Spaces
+
+### The Problem
+
+Kata's `.kata/` directory currently contains 22 top-level subdirectories with fundamentally different lifecycles, durability requirements, and query patterns — all at the same level:
+
+```
+.kata/
+├── config.json          # Permanent project identity
+├── stages/              # Reference methodology (changes rarely)
+├── bridge-runs/         # Per-session scaffolding (temporal)
+├── knowledge/           # Durable learnings (compounds over time)
+├── runs/                # Execution trees (temporal, high volume)
+├── tracking/            # Operational metrics (temporal)
+├── kataka/              # Agent registry (permanent, slow change)
+├── dojo/                # Reflections (permanent knowledge)
+├── cycles/              # Active work periods (temporal)
+├── ... (12 more directories)
+```
+
+There is no structural signal about which data is permanent vs. temporal, which should be loaded at session start vs. on-demand, or which compounds in value vs. flows through and gets processed.
+
+### What This Causes
+
+**1. Agent bootstrapping is scatter-gather.** A kataka agent needs identity from `kataka/`, methodology from `stages/` + `flavors/` + `pipelines/`, capabilities from `skill/` + `prompts/`, and project context from `config.json` + `KATA.md`. That's 7+ directories to establish "who am I and how do I work."
+
+**2. Knowledge is trapped in operational scaffolding.** Observations, decisions, and artifacts are recorded inside `runs/<id>/` — locked in the execution tree. Querying "all friction observations across 10 keikos" requires walking every run directory, reading every observation JSONL file, and aggregating. The knowledge is there but structurally inaccessible.
+
+**3. Conflation of lifecycles causes predictable failures.** When permanent knowledge (learnings) sits next to temporal state (bridge-runs) with no structural distinction:
+- Agents waste context loading operational scaffolding when seeking knowledge
+- Archival decisions are unclear — what can be cleaned up vs. what must be preserved?
+- Growth patterns clash — knowledge grows steadily; operations fluctuate wildly
+
+**4. nanograph integration has no clear scope.** When everything is flat, what gets indexed? Graphing operational scaffolding alongside durable knowledge produces noise. The graph needs a clean, well-defined input.
+
+### The Insight
+
+Ars Contexta's three-space architecture (Heinrich, 2026) demonstrates that separating data by **durability, growth pattern, and query pattern** prevents these failures structurally. The key insight: these aren't organizational preferences — they're failure-mode prevention. Data with different lifecycles in the same space will eventually degrade both.
+
+Kata already implicitly has three spaces. The data naturally falls into identity, knowledge, and operations. Three-space separation makes this explicit, giving agents and humans structural signals about what data means and how to interact with it.
+
+---
+
+## The Three Spaces
+
+### self/ — Identity & Methodology
+
+> *Japanese alias: shin (心) — heart, core, mind*
+>
+> "Who am I? How do I work?"
+
+| Property | Value |
+|----------|-------|
+| **Durability** | Permanent, evolves slowly |
+| **Growth** | Tens of files, changes deliberately |
+| **Load pattern** | Full load at session start |
+| **Update frequency** | Methodology changes per-keiko at most; config changes at init |
+| **Content** | Project config, agent constitution, stage definitions, flavors, pipelines, templates, prompts, skills, vocabularies, saved katas, agent registry |
+
+```
+.kata/self/
+├── config.json                    # Project settings
+├── KATA.md                        # Agent constitution
+├── methodology/                   # How work gets done
+│   ├── stages/                    # Stage definitions (builtin + custom)
+│   ├── flavors/                   # Named step compositions
+│   ├── pipelines/                 # Stage sequences
+│   └── templates/                 # Pipeline templates
+├── capabilities/                  # What agents can do
+│   ├── skill/                     # Agent skill files
+│   ├── prompts/                   # LLM instruction templates
+│   ├── vocabularies/              # Domain terminology
+│   └── katas/                     # Saved kata sequences
+└── agents/                        # Who the agents are
+    └── <kataka-id>.json           # Kataka registration
+```
+
+**Why this grouping**: Everything in `self/` answers the question an agent asks on boot: "What is this project, how does it work, and what can I do?" Loading `self/` completely gives an agent full orientation. Nothing temporal, nothing that changes mid-session.
+
+**Evolution pattern**: New flavors emerge from friction patterns (promoted from cooldown). New katas crystallize from successful sequences. New agents get registered. The methodology itself improves — but deliberately, as a result of the learning loop. `self/` is the *output* of methodology evolution, not the process.
+
+### knowledge/ — Accumulated Wisdom
+
+> *Japanese alias: chi (智) — wisdom*
+>
+> "What have we learned?"
+
+| Property | Value |
+|----------|-------|
+| **Durability** | Permanent, worth finding again |
+| **Growth** | Steady, compounds over time (10-50 items per keiko) |
+| **Load pattern** | Progressive disclosure — filter by stage/category/domain, then load details |
+| **Update frequency** | Learnings: versioned mutations. Promoted items: write-once. Dojo: per-cycle. |
+| **Content** | Learnings, promoted observations, promoted decisions, artifacts index, governance rules, execution history, dojo reflections |
+
+```
+.kata/knowledge/
+├── learnings/                     # Extracted patterns (versioned)
+│   └── <id>.json
+├── observations/                  # Promoted from runs (durable)
+│   └── <id>.json
+├── decisions/                     # Promoted from runs (durable)
+│   └── <id>.json
+├── artifacts/                     # Global artifact index
+│   └── <id>.json
+├── rules/                         # Extracted governance
+│   └── <id>.json
+├── history/                       # Execution records (append-only)
+│   └── <id>.json
+└── dojo/                          # Reflections & training
+    ├── diary/                     # Per-cycle journal
+    │   └── <cycle-id>.json
+    ├── sessions/                  # Learning artifacts
+    │   └── <id>.json
+    └── sources.json               # Reference sources
+```
+
+**Why this grouping**: Everything in `knowledge/` answers the question: "What does this project know?" Learnings compound. Promoted observations are worth finding again. History provides provenance. Dojo provides reflection. All queryable, all permanent, all growing in value.
+
+**The promotion concept**: Raw observations and decisions are captured in `ops/runs/` during execution. During cooldown (or via manual `kata promote`), significant items get **promoted** to `knowledge/`. The original stays in the run tree (append-only, never modified). The promoted copy lives in `knowledge/` where it's queryable across all runs without walking the run tree.
+
+**Content moves from temporal to durable, never backward.** An observation promoted to `knowledge/observations/` is a declaration: "This is worth remembering." It becomes a node that nanograph can index, that dojo can query, that cooldown can aggregate across cycles.
+
+### ops/ — Active Operations
+
+> *Japanese alias: do (動) — action, movement*
+>
+> "What's happening right now?"
+
+| Property | Value |
+|----------|-------|
+| **Durability** | Temporal, flows through and gets processed |
+| **Growth** | Fluctuating — fills during active work, can be archived after cooldown |
+| **Load pattern** | Targeted — active cycle, current run, today's session |
+| **Update frequency** | High during execution, dormant between cycles |
+| **Content** | Active cycles, execution run trees, bridge-run metadata, token tracking, session logs |
+
+```
+.kata/ops/
+├── cycles/                        # Cycle definitions
+│   └── <id>.json
+├── runs/                          # Execution trees
+│   └── <run-id>/
+│       ├── run.json               # Run metadata
+│       ├── observations.jsonl     # Raw observations (append-only)
+│       ├── decisions.jsonl        # Raw decisions (append-only)
+│       ├── artifact-index.jsonl   # Artifact references
+│       └── stages/                # Per-stage execution state
+│           └── <category>/
+│               ├── state.json
+│               ├── observations.jsonl
+│               └── flavors/...
+├── bridge-runs/                   # Session bridge metadata
+│   └── <run-id>.json
+├── tracking/                      # Token/cost usage
+│   └── usage.json
+└── sessions/                      # Session logs
+    └── <id>.json
+```
+
+**Why this grouping**: Everything in `ops/` answers: "What's in motion?" Active cycles, running executions, session state. This data is important *now* but its long-term value is in what gets promoted to `knowledge/`, not in the raw operational detail.
+
+**Archival pattern**: After cooldown completes and knowledge promotion runs, the cycle's operational data has been processed. Run trees can be archived (compressed, moved to `ops/archive/`) without losing any durable value — that value now lives in `knowledge/`. This keeps `ops/` lean and current.
+
+---
+
+## The Self-Improvement Loop Through Three Spaces
+
+The three spaces map directly to the phases of Kata's learning loop:
+
+```
+                    ┌─────────────────────────────────────┐
+                    │                                     │
+                    ▼                                     │
+            ┌──────────────┐                              │
+            │   self/      │  Load methodology            │
+            │   (shin)     │  Bootstrap agent              │
+            └──────┬───────┘                              │
+                   │                                      │
+                   ▼                                      │
+            ┌──────────────┐                              │
+            │   ops/       │  Execute work                │
+            │   (do)       │  Capture observations         │
+            │              │  Record decisions              │
+            └──────┬───────┘                              │
+                   │  promote                             │
+                   ▼                                      │
+            ┌──────────────┐                              │
+            │  knowledge/  │  Extract patterns             │
+            │  (chi)       │  Cooldown analysis            │
+            │              │  Dojo training                │
+            └──────┬───────┘                              │
+                   │  crystallize                         │
+                   │  (new flavors, katas, rules)         │
+                   └──────────────────────────────────────┘
+```
+
+Each space plays a distinct role:
+- **self/** is where methodology lives and evolves deliberately
+- **ops/** is where raw execution happens and raw signal is captured
+- **knowledge/** is where signal gets refined into durable understanding
+
+The loop is: **load → execute → promote → understand → crystallize → load better**
+
+---
+
+## User Journey: The Solo Developer
+
+### Day 1: Init
+
+```bash
+kata init
+```
+
+Three spaces are created. `self/` has the project config, builtin stages, default skills. `knowledge/` and `ops/` are empty — there's nothing to know and nothing happening yet.
+
+### Week 1-4: First Keikos
+
+The developer creates cycles, adds bets, executes work. `ops/` fills with run trees — observations, decisions, artifacts captured during execution. `self/` gets its first custom flavor (a "tdd-first" approach that works well for this project).
+
+### First Cooldown
+
+Cooldown runs. The significant observations from `ops/runs/` get promoted to `knowledge/observations/`. Learnings are extracted and stored in `knowledge/learnings/`. The cycle diary is written to `knowledge/dojo/diary/`. The operational scaffolding stays in `ops/` for audit trails.
+
+**This is the moment knowledge/ comes alive.** Before cooldown, knowledge was scattered in run trees. After, it's consolidated and queryable.
+
+### Month 2-3: Knowledge Compounds
+
+After 5+ keikos, `knowledge/` has dozens of learnings, hundreds of promoted observations, multiple diary entries. Claude Sensei can now answer: "What friction patterns keep recurring?" in one query against `knowledge/observations/`, not by walking 50 run directories.
+
+A new kataka agent is registered. It loads `self/` — immediately knows the methodology, the custom flavors, the project identity. It loads relevant `knowledge/` — learnings for its stage type, promoted patterns from past work. It's oriented in seconds, not minutes.
+
+### Dojo Training
+
+The developer asks for a training session. Sensei draws from `knowledge/`:
+- "Across 8 keikos, here are the 5 most recurring friction points."
+- "You made this decision in Keiko 3. Here's what happened. In Keiko 7, you faced the same situation differently."
+- "These 12 observations were captured but never promoted to learnings. Let's review."
+- "Your 'research' stage has friction around scope. Should we create a new flavor?"
+
+The training produces a new flavor definition, which gets saved to `self/methodology/flavors/`. The methodology evolves.
+
+### Methodology Evolution
+
+Over time, `self/` grows slowly but meaningfully:
+- New flavors from friction patterns
+- New katas from successful sequences
+- New agents registered for different work types
+- Prompts refined based on what works
+
+Each addition represents a distilled insight about how work should be done. `self/` is the crystallized output of the learning loop.
+
+### nanograph Integration (v1 late-stage)
+
+When nanograph arrives, it indexes `knowledge/` — the clean, promoted, meaningful dataset. Every node is a learning, observation, decision, or artifact worth remembering. Typed edges connect them: `cited_by`, `contradicts`, `promoted_from`. The graph is born clean because three-space separation already ensured only durable knowledge lives in the space being indexed.
+
+---
+
+## Current State → Target State
+
+### Current KATA_DIRS Mapping
+
+| Current Directory | Target Space | Target Path |
+|-------------------|-------------|-------------|
+| `config.json` | self/ | `self/config.json` |
+| `stages/` | self/ | `self/methodology/stages/` |
+| `flavors/` | self/ | `self/methodology/flavors/` |
+| `pipelines/` | self/ | `self/methodology/pipelines/` |
+| `templates/` | self/ | `self/methodology/templates/` |
+| `prompts/` | self/ | `self/capabilities/prompts/` |
+| `skill/` | self/ | `self/capabilities/skill/` |
+| `vocabularies/` | self/ | `self/capabilities/vocabularies/` |
+| `katas/` | self/ | `self/capabilities/katas/` |
+| `kataka/` | self/ | `self/agents/` |
+| `knowledge/` | knowledge/ | `knowledge/learnings/` |
+| `history/` | knowledge/ | `knowledge/history/` |
+| `rules/` | knowledge/ | `knowledge/rules/` |
+| `artifacts/` | knowledge/ | `knowledge/artifacts/` |
+| `dojo/` | knowledge/ | `knowledge/dojo/` |
+| `cycles/` | ops/ | `ops/cycles/` |
+| `runs/` | ops/ | `ops/runs/` |
+| `bridge-runs/` | ops/ | `ops/bridge-runs/` |
+| `tracking/` | ops/ | `ops/tracking/` |
+| `sessions/` | ops/ | `ops/sessions/` |
+
+### New Concepts (Not in Current Structure)
+
+| New Directory | Space | Purpose |
+|---------------|-------|---------|
+| `knowledge/observations/` | knowledge/ | Promoted observations from runs |
+| `knowledge/decisions/` | knowledge/ | Promoted decisions from runs |
+| `ops/archive/` | ops/ | Compressed completed cycle data |
+
+---
+
+## Knowledge Promotion Pipeline
+
+The critical new mechanism that bridges `ops/` and `knowledge/`.
+
+### What Gets Promoted
+
+Not everything. Promotion is selective — it's the "what's worth remembering" filter.
+
+| Source (ops/) | Target (knowledge/) | Promotion Criteria |
+|---------------|--------------------|--------------------|
+| `runs/<id>/observations.jsonl` | `knowledge/observations/<id>.json` | High severity, recurring pattern, human-flagged, or cooldown-selected |
+| `runs/<id>/decisions.jsonl` | `knowledge/decisions/<id>.json` | Significant decisions (architecture, methodology), outcomes recorded |
+| Run artifacts | `knowledge/artifacts/<id>.json` | Durable deliverables, not intermediate files |
+| Learning extractions | `knowledge/learnings/<id>.json` | Already promoted (existing cooldown behavior) |
+
+### When Promotion Happens
+
+**Automatic (during cooldown)**: When cooldown runs, it identifies significant observations and decisions from the cycle's runs and promotes them. This is the primary promotion path.
+
+**Manual (`kata promote`)**: A human or agent can explicitly promote an observation, decision, or artifact at any time. For when something is clearly important but cooldown hasn't run yet.
+
+**Condition-based (future)**: "This observation type has appeared in 3+ runs" triggers automatic promotion. Condition-based promotion is a Phase 2 capability.
+
+### Promotion Preserves Provenance
+
+Every promoted item retains a link back to its source:
+
+```json
+{
+  "id": "promoted-obs-uuid",
+  "content": "Test coverage friction when switching between research and build stages",
+  "type": "friction",
+  "severity": "high",
+  "promotedFrom": {
+    "runId": "original-run-uuid",
+    "sourcePath": "ops/runs/<run-id>/observations.jsonl",
+    "lineIndex": 42,
+    "promotedAt": "2026-03-15T10:00:00Z",
+    "promotedBy": "cooldown"  // or "manual" or "condition"
+  },
+  "katakaId": "agent-uuid",
+  "cycleId": "cycle-uuid",
+  "betId": "bet-uuid",
+  "recordedAt": "2026-03-14T15:30:00Z"
+}
+```
+
+This provenance chain is what nanograph later indexes as `promoted_from` edges, enabling queries like "show me the evidence chain for this learning."
+
+---
+
+## Naming Convention
+
+Following Kata's established pattern: plain English in code, Japanese aliases for CLI experience.
+
+### Directory Names (Code)
+
+| Space | Directory | Constant Key |
+|-------|-----------|-------------|
+| Identity | `self/` | `KATA_DIRS.self` |
+| Knowledge | `knowledge/` | `KATA_DIRS.knowledge` |
+| Operations | `ops/` | `KATA_DIRS.ops` |
+
+### CLI Aliases (Themed)
+
+| English | Japanese | Meaning | Usage |
+|---------|----------|---------|-------|
+| `self/` | shin (心) | Heart, core, mind | "The dojo's shin" |
+| `knowledge/` | chi (智) | Wisdom | "Query the chi" |
+| `ops/` | do (動) | Action, movement | "What's active in the do" |
+| `promote` | ageru (上げる) | To raise, elevate | `kata ageru` / `kata promote` |
+| `archive` | shimau (仕舞う) | To put away, finish | `kata shimau` / `kata archive` |
+
+### KATA_DIRS Update
+
+```typescript
+export const KATA_DIRS = {
+  root: '.kata',
+  // Three spaces
+  self: 'self',
+  knowledge: 'knowledge',
+  ops: 'ops',
+  // self/ subdirectories
+  methodology: 'self/methodology',
+  stages: 'self/methodology/stages',
+  flavors: 'self/methodology/flavors',
+  pipelines: 'self/methodology/pipelines',
+  templates: 'self/methodology/templates',
+  capabilities: 'self/capabilities',
+  skill: 'self/capabilities/skill',
+  prompts: 'self/capabilities/prompts',
+  vocabularies: 'self/capabilities/vocabularies',
+  katas: 'self/capabilities/katas',
+  agents: 'self/agents',
+  // knowledge/ subdirectories
+  learnings: 'knowledge/learnings',
+  observations: 'knowledge/observations',
+  decisions: 'knowledge/decisions',
+  artifacts: 'knowledge/artifacts',
+  rules: 'knowledge/rules',
+  history: 'knowledge/history',
+  dojo: 'knowledge/dojo',
+  diary: 'knowledge/dojo/diary',
+  dojoSessions: 'knowledge/dojo/sessions',
+  // ops/ subdirectories
+  cycles: 'ops/cycles',
+  runs: 'ops/runs',
+  bridgeRuns: 'ops/bridge-runs',
+  tracking: 'ops/tracking',
+  sessions: 'ops/sessions',
+  archive: 'ops/archive',
+  // legacy (kept for migration detection)
+  config: 'self/config.json',
+  builtin: 'self/methodology/stages/builtin',
+} as const;
+```
+
+---
+
+## Sequencing: Before nanograph
+
+Three-space separation is a **v1 foundational feature**. nanograph is a **v1 late-stage capability**. The sequencing is:
+
+```
+Three-Space Architecture → Remaining v1 features → nanograph integration → v1 publish
+```
+
+### Why before nanograph
+
+1. **Three-space creates the data that nanograph indexes.** Without knowledge promotion, observations stay trapped in run trees. nanograph would need to walk every run to find them. Promotion creates the clean, queryable dataset in `knowledge/` that nanograph formalizes.
+
+2. **nanograph needs clear boundaries.** Indexing a flat `.kata/` produces a graph with operational noise mixed with durable knowledge. Indexing only `knowledge/` means every node is meaningful.
+
+3. **Three-space delivers value immediately.** Agent bootstrapping, cross-run queries, and dojo training all improve with just the directory restructure + promotion pipeline, before nanograph adds graph traversal.
+
+4. **Migration is cheaper before nanograph.** Once nanograph has indexed the structure, changing it means re-indexing. Restructure first.
+
+### What three-space enables for nanograph
+
+- **Graph scope**: Index `knowledge/` only — no operational noise
+- **Node types**: Already clean — learnings, observations, decisions, artifacts, rules, diary entries
+- **Cross-space edges**: `promoted_from` (ops → knowledge) edges have real filesystem provenance
+- **Progressive disclosure**: Topic hierarchy in `knowledge/` maps directly to graph navigation
+- **Condition-based triggers**: Knowledge health queries run against `knowledge/` space, not full `.kata/`
+
+---
+
+## Implementation Bets
+
+### Dependency Graph
+
+```
+Bet 1 (Schema & Migration)
+├── Bet 2 (Self-Space Bootstrap)     [parallel]
+├── Bet 3 (Knowledge Promotion)      [parallel]
+│   ├── Bet 4 (Cross-Run Queries)
+│   │   ├── Bet 5 (Dojo from Knowledge)  [parallel]
+│   │   └── Bet 6 (Knowledge Lifecycle)  [parallel]
+│   └── Bet 7 (Ops Archival)
+```
+
+### Bet 1: Three-Space Schema & Migration (Foundation)
+
+Define the formal schema mapping. Build `kata migrate` command with dry-run, backup, and rollback. Update `KATA_DIRS` constant. Update `kata init` to create three-space structure for new projects.
+
+**Exit criteria**: Fresh `kata init` creates three-space structure. Existing `.kata/` projects can migrate safely with `kata migrate`. All tests pass on new structure.
+
+**Scope**: KATA_DIRS update, JsonStore path resolution, init handler, migration command, test updates.
+
+### Bet 2: Self-Space Agent Bootstrap
+
+Consolidate identity loading. Update `formatAgentContext()` to load from `self/` as a single root. Simplify session orientation.
+
+**Exit criteria**: A new kataka loads `self/` and has complete context. Agent onboarding tokens measurably reduced. `kata kiai context <run-id>` produces richer context from consolidated self-space.
+
+**Depends on**: Bet 1
+
+### Bet 3: Knowledge Promotion Pipeline
+
+Implement promotion of observations, decisions, and artifacts from `ops/runs/` into `knowledge/`. Define promotion criteria. Cooldown triggers bulk promotion. Manual promotion via `kata promote` (alias: `kata ageru`).
+
+**Exit criteria**: After cooldown, significant observations appear in `knowledge/observations/`. Manual promotion works via CLI. Promoted items retain provenance (link back to source run).
+
+**Depends on**: Bet 1
+
+### Bet 4: Cross-Run Knowledge Queries
+
+Build query capabilities on promoted knowledge. Feed results into cooldown, dojo, and agent context.
+
+**Exit criteria**: `kata knowledge query --type observation --tag friction` returns results across all promoted knowledge. Cooldown uses knowledge queries instead of run-walking. Query performance is O(knowledge) not O(runs).
+
+**Depends on**: Bet 3
+
+### Bet 5: Dojo From Knowledge
+
+Power dojo training sessions from knowledge space queries. Pattern review, decision replay, knowledge gap identification, methodology evolution suggestions.
+
+**Exit criteria**: `kata dojo open` creates sessions grounded in `knowledge/` queries. Training produces actionable methodology improvements that can be saved to `self/`.
+
+**Depends on**: Bet 4
+
+### Bet 6: Knowledge Lifecycle
+
+Implement decay, archival, pruning, and condition-based maintenance for knowledge space. The "art of forgetting" — the system improves by also removing.
+
+**Exit criteria**: Knowledge nodes have active lifecycle. Stale items decay. Contradictions are flagged. Condition-based maintenance surfaces actionable prompts during cooldown.
+
+**Depends on**: Bet 4
+
+### Bet 7: Ops Archival
+
+After cooldown + promotion, allow archival of completed cycle operational data. Keep `ops/` lean.
+
+**Exit criteria**: Completed cycles can be archived via `kata ops archive` (alias: `kata shimau`). Archived data is recoverable. Knowledge persists regardless of archival.
+
+**Depends on**: Bet 3
+
+---
+
+## Non-Goals
+
+- **Changing the domain model.** Zod schemas for Stage, Pipeline, Cycle, Learning, etc. remain unchanged. Three-space separation is a storage organization change, not a domain model change.
+- **Breaking the existing API.** `KnowledgeStore`, `StageRegistry`, and other interfaces keep their signatures. The path resolution layer changes, not the consumer API.
+- **Requiring nanograph.** Three-space delivers full value with JSON files. nanograph amplifies it later.
+- **Forcing immediate migration.** A `kata migrate` command handles the transition. Legacy flat structures are detected and users are guided to migrate.
+
+---
+
+## Inspiration
+
+This architecture is informed by:
+
+- **Ars Contexta's three-space model** (Heinrich, 2026): `self/`, `notes/`, `ops/` separation based on durability, growth, and query patterns. Demonstrates that conflating spaces with different lifecycles causes specific, predictable failures.
+- **"The Art of Forgetting"** (Cornelius, Agentic Note-Taking #20): The most important operation in a functioning knowledge system is removal. Knowledge systems fail when accumulation outpaces release.
+- **"Notes Without Reasons"** (Cornelius, Agentic Note-Taking #23): Curated connections carry reasons that agents can evaluate. Embedding-based connections produce fog.
+- **"What No Single Note Contains"** (Cornelius, Agentic Note-Taking #25): Value lives between notes — in the curated topology, the traversal paths. The graph's value is in its shape.
+- **"Living Memory"** (Cornelius, Agentic Note-Taking #19): Three memory systems — semantic (knowledge graph), episodic (self), procedural (methodology) — map directly to knowledge/, self/, and self/methodology/.
+- **Kata's own knowledge graph spike** ([spike-knowledge-graph.md](../pipeline/spike-knowledge-graph.md)): 70% of queries are simple filters, 30% need graph traversal. Three-space separation makes the simple queries fast; nanograph handles the complex ones.
+- **Cognitive science**: Knowledge decay mirrors synaptic pruning. Promotion mirrors memory consolidation. Three-space separation mirrors the distinction between working memory (ops), long-term memory (knowledge), and procedural memory (self).
+
+---
+
+*This is a vision document. It will be refined as implementation reveals edge cases and real usage patterns. The bet structure ensures we can deliver incrementally — each bet ships value independently.*


### PR DESCRIPTION
## Summary

- Adds `docs/vision/three-space-architecture.md` — the vision document for restructuring `.kata/` into three spaces (`self/`, `knowledge/`, `ops/`) based on data durability, growth patterns, and query characteristics
- Adds `docs/vision/knowledge-graph-vision.md` (previously untracked) and updates its pre-integration checklist to require three-space as a prerequisite
- Adds `docs-site/vision/three-space.md` symlink for Mintlify docs

## Context

Epic: #261 — Three-Space Architecture (San-Ma 三間)
Milestone: [Three-Space Architecture](https://github.com/cmbays/kata/milestone/1)
Bets: #262, #263, #264, #265, #266, #267, #268

## Test plan

- [ ] Vision doc renders correctly in Mintlify docs-site
- [ ] All companion doc links resolve
- [ ] Milestone and bet issues are properly cross-referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture vision documentation detailing the three-space framework (self, knowledge, ops) for organizing accumulated data and enabling cross-run queries.
  * Added knowledge graph integration documentation outlining schema design principles, query patterns, and phased migration strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->