### PR TITLE
fix: make kime record --reasoning optional (closes #236)

### DIFF
--- a/src/cli/commands/decision.test.ts
+++ b/src/cli/commands/decision.test.ts
@@ -442,7 +442,7 @@ describe('registerDecisionCommands — decision record', () => {
     expect(output.context).toEqual({});
     expect(output.options).toEqual([]);
     expect(output.confidence).toBe(1.0);
-    expect(output.reasoning).toBe('(no reasoning provided)');
+    expect(output.reasoning).toBe('');
     expect(output.selection).toBe('fast-path');
   });
 

--- a/src/cli/commands/decision.ts
+++ b/src/cli/commands/decision.ts
@@ -134,7 +134,7 @@ export function registerDecisionCommands(parent: Command): void {
         context,
         options,
         selection: selected,
-        reasoning: (localOpts.reasoning as string | undefined) ?? '(no reasoning provided)',
+        reasoning: (localOpts.reasoning as string | undefined) ?? '',
         confidence,
         decidedAt: now,
         ...(isLowConfidence ? { lowConfidence: true } : {}),

--- a/src/domain/types/run-state.ts
+++ b/src/domain/types/run-state.ts
@@ -218,8 +218,8 @@ export const DecisionEntrySchema = z.object({
   options: z.array(z.string()),
   /** The chosen option. */
   selection: z.string().min(1),
-  /** Orchestrator's reasoning for the selection. */
-  reasoning: z.string().min(1),
+  /** Orchestrator's reasoning for the selection (empty string when omitted). */
+  reasoning: z.string(),
   /** Confidence in the selection: [0, 1]. */
   confidence: z.number().min(0).max(1),
   /** ISO 8601 timestamp when the decision was made. */


### PR DESCRIPTION
## Summary

- `DecisionEntrySchema.reasoning` relaxed from `z.string().min(1)` to `z.string()` — empty string is now valid at the schema level
- CLI default for `--reasoning` changed from `'(no reasoning provided)'` to `''` (empty string)
- Updated the one test that expected the old boilerplate default

## What was required vs optional before

`--reasoning` was already marked as `.option()` (not `.requiredOption()`) in the CLI, so it was never enforced at the Commander level. The breakage was downstream: `DecisionEntrySchema.reasoning: z.string().min(1)` would reject the written entry if the CLI defaulted to an empty string. The boilerplate `'(no reasoning provided)'` was a workaround — now removed.

## Test plan

- [ ] `npx vitest run src/cli/commands/decision.test.ts` — all tests pass including the "minimal required args" test that now expects `reasoning: ''`
- [ ] `npx vitest run` — full suite (3013 tests) passes
- [ ] Manual: `kata kime record <run-id> --stage research --type flavor-selection --selected foo` succeeds without `--reasoning`

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decision records with missing reasoning now display as empty fields instead of showing placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->