### PR TITLE
fix: make maki record --flavor optional (closes #251)

### DIFF
--- a/src/cli/commands/artifact.test.ts
+++ b/src/cli/commands/artifact.test.ts
@@ -274,6 +274,88 @@ describe('registerArtifactCommands — artifact record', () => {
     expect(entries[0].step).toBe('gather-context');
   });
 
+  it('records an artifact without --flavor at stage level', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'output.md');
+    writeFileSync(srcFile, '# Output', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      // No --flavor
+      '--step', 'gather',
+      '--file', srcFile,
+      '--summary', 'Flavorless output',
+    ]);
+
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].flavor).toBeNull();
+    expect(entries[0].step).toBe('gather');
+    expect(entries[0].type).toBe('artifact');
+    expect(entries[0].summary).toBe('Flavorless output');
+    // File goes to stage-level artifacts dir
+    expect(entries[0].filePath).toContain(join('stages', 'research', 'artifacts'));
+    const absoluteFilePath = join(runsDir, run.id, entries[0].filePath);
+    expect(existsSync(absoluteFilePath)).toBe(true);
+  });
+
+  it('records a synthesis without --flavor at stage level', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'synthesis.md');
+    writeFileSync(srcFile, '# Synthesis', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      // No --flavor
+      '--file', srcFile,
+      '--summary', 'Stage synthesis',
+      '--type', 'synthesis',
+    ]);
+
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].flavor).toBeNull();
+    expect(entries[0].type).toBe('synthesis');
+    expect(entries[0].fileName).toBe('synthesis.md');
+    // Synthesis goes to stage-level synthesis.md
+    expect(entries[0].filePath).toBe(join('stages', 'research', 'synthesis.md'));
+  });
+
+  it('outputs JSON without Flavor field when --flavor is omitted', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'out.md');
+    writeFileSync(srcFile, '# Out', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--step', 'gather',
+      '--file', srcFile,
+      '--summary', 'No flavor',
+    ]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.flavor).toBeNull();
+    expect(parsed.type).toBe('artifact');
+  });
+
   it('throws on invalid --type value', async () => {
     const run = makeRun();
     createRunTree(runsDir, run);

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -9,6 +9,15 @@ import { ArtifactIndexEntrySchema } from '@domain/types/run-state.js';
 import type { StageCategory } from '@domain/types/stage.js';
 import { StageCategorySchema } from '@domain/types/stage.js';
 
+/** Paths for a stage-level (flavorless) artifact. */
+function stageLevelPaths(paths: ReturnType<typeof runPaths>, stage: StageCategory) {
+  return {
+    artifactsDir: join(paths.runDir, 'stages', stage, 'artifacts'),
+    synthesisDest: join(paths.runDir, 'stages', stage, 'synthesis.md'),
+    artifactIndexJsonl: join(paths.runDir, 'stages', stage, 'artifact-index.jsonl'),
+  };
+}
+
 export function registerArtifactCommands(parent: Command): void {
   const artifact = parent
     .command('artifact')
@@ -20,7 +29,7 @@ export function registerArtifactCommands(parent: Command): void {
     .command('record <run-id>')
     .description('Record an artifact file into a run\'s state')
     .requiredOption('--stage <category>', 'Stage category (research|plan|build|review)')
-    .requiredOption('--flavor <name>', 'Flavor that produced the artifact')
+    .option('--flavor <name>', 'Flavor that produced the artifact (optional — omit to record at stage level)')
     .option('--step <name>', 'Step that produced the artifact (omit for synthesis type)')
     .requiredOption('--file <path>', 'Path to the source artifact file')
     .requiredOption('--summary <description>', 'Short summary of the artifact content')
@@ -65,24 +74,43 @@ export function registerArtifactCommands(parent: Command): void {
       }
 
       const paths = runPaths(runsDir, runId);
-      const flavorDir = paths.flavorDir(stage, localOpts.flavor as string);
-      const flavorStateFile = paths.flavorStateJson(stage, localOpts.flavor as string);
-
-      // Ensure flavor directory exists (flavor may not have been explicitly initialized)
-      mkdirSync(flavorDir, { recursive: true });
+      const flavor = (localOpts.flavor as string | undefined) ?? null;
 
       // Synthesis artifacts are always named synthesis.md regardless of source filename
       const fileName = artifactType === 'synthesis' ? 'synthesis.md' : basename(sourcePath);
       let destPath: string;
+      let flavorIndexJsonl: string;
+      let flavorStateFile: string | null = null;
 
-      if (artifactType === 'synthesis') {
-        // Synthesis artifacts go at the flavor root as synthesis.md
-        destPath = paths.flavorSynthesis(stage, localOpts.flavor as string);
+      if (flavor !== null) {
+        const flavorDir = paths.flavorDir(stage, flavor);
+        flavorStateFile = paths.flavorStateJson(stage, flavor);
+
+        // Ensure flavor directory exists (flavor may not have been explicitly initialized)
+        mkdirSync(flavorDir, { recursive: true });
+
+        if (artifactType === 'synthesis') {
+          destPath = paths.flavorSynthesis(stage, flavor);
+        } else {
+          const artifactsDir = paths.flavorArtifactsDir(stage, flavor);
+          mkdirSync(artifactsDir, { recursive: true });
+          destPath = join(artifactsDir, fileName);
+        }
+
+        flavorIndexJsonl = paths.flavorArtifactIndexJsonl(stage, flavor);
       } else {
-        // Regular artifacts go in the artifacts/ subdirectory
-        const artifactsDir = paths.flavorArtifactsDir(stage, localOpts.flavor as string);
-        mkdirSync(artifactsDir, { recursive: true });
-        destPath = join(artifactsDir, fileName);
+        // No flavor — route to stage-level directories
+        const stagePaths = stageLevelPaths(paths, stage);
+
+        if (artifactType === 'synthesis') {
+          mkdirSync(join(paths.runDir, 'stages', stage), { recursive: true });
+          destPath = stagePaths.synthesisDest;
+        } else {
+          mkdirSync(stagePaths.artifactsDir, { recursive: true });
+          destPath = join(stagePaths.artifactsDir, fileName);
+        }
+
+        flavorIndexJsonl = stagePaths.artifactIndexJsonl;
       }
 
       // Copy the file
@@ -100,7 +128,7 @@ export function registerArtifactCommands(parent: Command): void {
       const entry = {
         id: randomUUID(),
         stageCategory: stage,
-        flavor: localOpts.flavor as string,
+        flavor,
         step: artifactType === 'synthesis' ? null : ((localOpts.step as string | undefined) ?? null),
         fileName,
         filePath: relFilePath,
@@ -109,27 +137,23 @@ export function registerArtifactCommands(parent: Command): void {
         recordedAt: new Date().toISOString(),
       };
 
-      // Append to flavor-level artifact-index.jsonl
-      JsonlStore.append(
-        paths.flavorArtifactIndexJsonl(stage, localOpts.flavor as string),
-        entry,
-        ArtifactIndexEntrySchema,
-      );
+      // Append to flavor-level (or stage-level) artifact-index.jsonl
+      JsonlStore.append(flavorIndexJsonl, entry, ArtifactIndexEntrySchema);
 
       // Append to run-level artifact-index.jsonl
       JsonlStore.append(paths.artifactIndexJsonl, entry, ArtifactIndexEntrySchema);
 
-      // Update flavor state.json step artifacts if applicable
-      if (artifactType === 'artifact' && existsSync(flavorStateFile)) {
+      // Update flavor state.json step artifacts if applicable (only when flavor is known)
+      if (artifactType === 'artifact' && flavor !== null && flavorStateFile !== null && existsSync(flavorStateFile)) {
         // existsSync guard ensures the file exists, so non-null assertion is safe
-        const flavorState = readFlavorState(runsDir, runId, stage, localOpts.flavor as string)!;
+        const flavorState = readFlavorState(runsDir, runId, stage, flavor)!;
         const stepName = localOpts.step as string; // non-null validated above
         const stepIndex = flavorState.steps.findIndex((s) => s.type === stepName);
 
         if (stepIndex === -1) {
           const known = flavorState.steps.map((s) => s.type).join(', ') || '(none)';
           throw new Error(
-            `Step "${stepName}" not found in flavor "${localOpts.flavor as string}" state. Known steps: ${known}`,
+            `Step "${stepName}" not found in flavor "${flavor}" state. Known steps: ${known}`,
           );
         }
         flavorState.steps[stepIndex]!.artifacts.push(relFilePath);
@@ -142,7 +166,9 @@ export function registerArtifactCommands(parent: Command): void {
         const label = artifactType === 'synthesis' ? 'synthesis' : `artifact`;
         console.log(`Recorded ${label}: ${fileName}`);
         console.log(`  Stage:  ${stage}`);
-        console.log(`  Flavor: ${localOpts.flavor as string}`);
+        if (flavor !== null) {
+          console.log(`  Flavor: ${flavor}`);
+        }
         if (artifactType === 'artifact' && localOpts.step) {
           console.log(`  Step:   ${localOpts.step as string}`);
         }

--- a/src/domain/types/run-state.test.ts
+++ b/src/domain/types/run-state.test.ts
@@ -293,13 +293,9 @@ describe('ArtifactIndexEntrySchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects null flavor for artifact type (cross-field invariant)', () => {
+  it('accepts null flavor for artifact type (stage-level recording without flavor classification)', () => {
     const result = ArtifactIndexEntrySchema.safeParse({ ...valid, flavor: null });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const flavorError = result.error.issues.find((i) => i.path.includes('flavor'));
-      expect(flavorError?.message).toContain('non-null');
-    }
+    expect(result.success).toBe(true);
   });
 
   it('rejects invalid type', () => {

--- a/src/domain/types/run-state.ts
+++ b/src/domain/types/run-state.ts
@@ -270,15 +270,15 @@ export type ArtifactIndexType = z.infer<typeof ArtifactIndexTypeSchema>;
 /**
  * An entry appended to artifact-index.jsonl (run-level and flavor-level).
  *
- * Cross-field invariant: `flavor` must be non-null when `type` is `'artifact'`.
- * Stage-level synthesis entries (`type === 'synthesis'`) may have `flavor: null`.
+ * `flavor` is nullable for both artifact and synthesis types — omitted when the
+ * artifact is recorded without flavor classification (stage-level placement).
  */
 export const ArtifactIndexEntrySchema = z.object({
   /** UUID generated at record time. */
   id: z.string().uuid(),
   /** Stage the artifact was produced in. */
   stageCategory: StageCategorySchema,
-  /** Flavor that produced the artifact. Null for stage-level synthesis artifacts. */
+  /** Flavor that produced the artifact. Null when recorded without flavor classification. */
   flavor: z.string().min(1).nullable(),
   /** Step that produced the artifact (nullable for synthesis artifacts). */
   step: z.string().nullable(),
@@ -292,14 +292,6 @@ export const ArtifactIndexEntrySchema = z.object({
   type: ArtifactIndexTypeSchema,
   /** ISO 8601 timestamp when the artifact was recorded. */
   recordedAt: z.string().datetime(),
-}).superRefine((val, ctx) => {
-  if (val.type === 'artifact' && val.flavor === null) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['flavor'],
-      message: 'flavor must be non-null for type "artifact"',
-    });
-  }
 });
 
 export type ArtifactIndexEntry = z.infer<typeof ArtifactIndexEntrySchema>;


### PR DESCRIPTION
## Summary

- `kata maki record` (alias `kata artifact record`) previously required `--flavor` as a `requiredOption`, causing an error when omitted
- `--flavor` is now an optional flag; omitting it records the artifact at the stage level instead of a flavor subdirectory
- The `ArtifactIndexEntrySchema` cross-field invariant (which rejected `null` flavor for `type === 'artifact'`) is removed — flavor is now nullable for both artifact and synthesis types
- Flavorless artifacts route to `stages/<category>/artifacts/<filename>` and flavorless synthesis routes to `stages/<category>/synthesis.md`
- The flavor-level `artifact-index.jsonl` write is replaced by a stage-level one when flavor is absent

## Test plan

- [x] 3016 tests passing across 147 files
- [x] New test: records artifact without `--flavor` at stage level, verifies `flavor: null` in index and correct file path
- [x] New test: records synthesis without `--flavor` at stage level
- [x] New test: `--json` output has `flavor: null` when omitted
- [x] Updated schema test: `null` flavor is now accepted for `type === 'artifact'`
- [x] All existing artifact and run-state tests continue to pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)