### PR TITLE
fix: eliminate duplicate error output (#246)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,16 @@
 import { createProgram } from './program.js';
+import { handleCommandError } from './utils.js';
 
 const program = createProgram();
-await program.parseAsync();
+
+// Avoid a bare top-level await. Node.js v20+ emits a spurious
+// "Warning: Detected unsettled top-level await" when an async action
+// (e.g. Inquirer prompt cancelled via EOF/SIGINT) causes the event loop
+// to drain before parseAsync resolves — making output look like duplicate
+// errors. Wrapping in a non-awaited .catch() keeps the same async semantics
+// without leaving a top-level await unsettled at process exit.
+// Commander's own validation errors (missing args, unknown commands) call
+// process.exit() internally and never reach this catch.
+program.parseAsync().catch((err: unknown) => {
+  handleCommandError(err, process.argv.includes('--verbose'));
+});


### PR DESCRIPTION
## Summary

- Replaces the bare `await program.parseAsync()` in `src/cli/index.ts` with a `.catch()` handler
- Node.js v20+ emits a `Warning: Detected unsettled top-level await` when the event loop drains before `parseAsync()` resolves — this happens when Inquirer throws `ExitPromptError` on prompt cancellation (EOF/Ctrl+D)
- The warning interleaved with `handleCommandError`'s output created the appearance of duplicate error messages
- No change to application logic: `withCommandContext` still catches all handler errors; Commander's own validation errors (missing args, unknown commands) call `process.exit()` internally and never reach the catch

## Test plan

- [x] `npm test` — 3013 tests, 147 files, all pass
- [x] `kata cycle new </dev/null` — before: warning + error; after: single clean error line
- [x] `kata cooldown` (missing required arg) — still prints exactly one `error:` line
- [x] `kata cycle status nonexistent` — still prints exactly one `Error:` line
- [x] `kata --cwd /tmp cycle status x` (no .kata dir) — still prints exactly one `Error:` line

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)