### PR TITLE
fix: surface absolute config path in loadConfigOutputMode warning (closes #228)

### DIFF
--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -6,6 +6,12 @@ import type { CommandContext } from './utils.js';
 import { ConfigNotFoundError } from '@shared/lib/errors.js';
 import { Command } from 'commander';
 
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+vi.mock('@shared/lib/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: warnMock, error: vi.fn() },
+  setLoggerOptions: vi.fn(),
+}));
+
 describe('resolveKataDir', () => {
   const testDir = join(tmpdir(), `kata-utils-test-${Date.now()}`);
   const kataDir = join(testDir, '.kata');
@@ -239,7 +245,8 @@ describe('withCommandContext', () => {
   // Issue #228 — loadConfigOutputMode should warn on malformed config.json
   it('emits a logger warn and falls back when config.json is malformed', async () => {
     // Write a malformed config.json
-    writeFileSync(join(testDir, '.kata', 'config.json'), 'not-valid-json{{{');
+    const configPath = join(testDir, '.kata', 'config.json');
+    writeFileSync(configPath, 'not-valid-json{{{');
 
     let captured: CommandContext | undefined;
     const handler = withCommandContext(async (ctx) => { captured = ctx; });
@@ -247,14 +254,18 @@ describe('withCommandContext', () => {
     const cmd = makeCmd(testDir);
     const localOpts = {};
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnMock.mockClear();
     await handler(localOpts, cmd);
-    warnSpy.mockRestore();
 
     // Command should still succeed (falls back to default)
     expect(captured).toBeDefined();
     // plain should remain false (default fallback)
     expect(captured!.globalOpts.plain).toBe(false);
+    // logger.warn must have been called with the config path and fallback message
+    expect(warnMock).toHaveBeenCalledOnce();
+    const [message] = warnMock.mock.calls[0]!;
+    expect(message).toContain(configPath);
+    expect(message).toContain('falling back to default output mode');
   });
 
   it('reads outputMode from valid config.json when set to plain', async () => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -103,7 +103,7 @@ function loadConfigOutputMode(kataDir: string): boolean {
     return config.outputMode === 'plain';
   } catch (err) {
     logger.warn(
-      `Failed to parse .kata/config.json — falling back to default output mode. ` +
+      `Failed to parse ${configPath} — falling back to default output mode. ` +
       `Error: ${err instanceof Error ? err.message : String(err)}`,
     );
     return false;


### PR DESCRIPTION
## Summary

- The `logger.warn` call in `loadConfigOutputMode`'s catch block used the string literal `'.kata/config.json'` instead of the absolute `configPath` variable — users had no actionable file location to fix. Now emits the full path.
- The malformed-config regression test (`emits a logger warn and falls back when config.json is malformed`) was asserting fallback behavior but not actually verifying the warning was emitted. The test used `console.warn` (wrong — logger writes to `process.stderr`) and even a `process.stderr.write` spy failed under vitest ESM module isolation. Fixed with `vi.hoisted` + `vi.mock` to give the test and the module-under-test a shared `warnMock`. Test now asserts `logger.warn` is called once with the absolute path and the fallback text.

## Test plan

- [x] `npx vitest run src/cli/utils.test.ts` — all 19 tests pass including the strengthened #228 test
- [x] Full suite `npx vitest run` — 3017 tests pass across 147 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)