### PR TITLE
fix: surface --yolo cooldown errors in --json mode (#257, #227)

### DIFF
--- a/src/cli/commands/cycle.test.ts
+++ b/src/cli/commands/cycle.test.ts
@@ -744,6 +744,81 @@ describe('registerCycleCommands', () => {
       // confirmed by code inspection: synthesisError is spread into the output when set.
     }, 60000);
 
+    // Issue #257 — --yolo --json must emit a valid JSON object even when synthesis fails.
+    // Synthesis failure is simulated by writing no result file (the subprocess call will fail
+    // with ENOENT for 'claude', caught internally, and the yolo block must still emit JSON).
+    it('--yolo --json emits valid JSON with synthesisProposals key when claude is unavailable', async () => {
+      const manager = new CycleManager(cyclesDir, JsonStore);
+      const cycle = manager.create({ tokenBudget: 50000 }, 'Yolo Failure JSON Test');
+
+      const synthesisDir = join(kataDir, 'synthesis');
+      mkdirSync(synthesisDir, { recursive: true });
+
+      // PATH manipulation makes 'claude' unavailable — execFileSync throws ENOENT,
+      // which the --yolo handler catches and converts into synthesisError in JSON output.
+      const originalPath = process.env['PATH'];
+      process.env['PATH'] = '';
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--json', '--cwd', baseDir,
+        'cooldown', cycle.id, '--yolo',
+      ]);
+
+      process.env['PATH'] = originalPath;
+      warnSpy.mockRestore();
+
+      // Must have emitted exactly one JSON object to stdout (#257 fix)
+      const firstCall = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(firstCall).toBeDefined();
+      const parsed = JSON.parse(firstCall);
+
+      // Core fields always present
+      expect(parsed.synthesisProposals).toEqual([]);
+      // report is present because complete() succeeded despite synthesis failure
+      expect(parsed.report).toBeDefined();
+      expect(parsed.proposals).toBeDefined();
+      // synthesisError surfaces the failure message
+      expect(typeof parsed.synthesisError).toBe('string');
+
+      // Cycle must still be complete
+      const updated = manager.get(cycle.id);
+      expect(updated.state).toBe('complete');
+    }, 30000);
+
+    // Issue #227 — non-JSON --yolo mode must surface synthesis errors to the user.
+    it('--yolo non-JSON mode surfaces synthesis failure via console.warn', async () => {
+      const manager = new CycleManager(cyclesDir, JsonStore);
+      const cycle = manager.create({ tokenBudget: 50000 }, 'Yolo Failure Non-JSON Test');
+
+      const synthesisDir = join(kataDir, 'synthesis');
+      mkdirSync(synthesisDir, { recursive: true });
+
+      const originalPath = process.env['PATH'];
+      process.env['PATH'] = '';
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--plain', '--cwd', baseDir,
+        'cooldown', cycle.id, '--yolo',
+      ]);
+
+      const warnCalls = warnSpy.mock.calls.map((c) => c[0] as string).join('\n');
+      process.env['PATH'] = originalPath;
+      warnSpy.mockRestore();
+
+      // User-visible warning must mention the failure (#227)
+      expect(warnCalls).toContain('synthesis failure');
+
+      // Cycle must still complete
+      const updated = manager.get(cycle.id);
+      expect(updated.state).toBe('complete');
+    }, 30000);
+
     it('--auto-accept-suggestions includes suggestionReview in --json output', async () => {
       const { RuleRegistry } = await import('@infra/registries/rule-registry.js');
       const rulesDir = join(kataDir, 'rules');

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path';
 import type { Command } from 'commander';
-import { logger } from '@shared/lib/logger.js';
 import { CycleManager } from '@domain/services/cycle-manager.js';
 import { KnowledgeStore } from '@infra/knowledge/knowledge-store.js';
 import { JsonStore } from '@infra/persistence/json-store.js';
@@ -683,7 +682,21 @@ export function registerCycleCommands(parent: Command): void {
 
       // --- --yolo mode: prepare + claude for synthesis + apply high-confidence proposals ---
       if (localOpts.yolo) {
-        const prepareResult = await session.prepare(cycleId, [], localOpts.depth, { force });
+        // Outer try/catch: ensures --json mode always emits a valid JSON object to
+        // stdout even when prepare() or complete() throw (fixes #257 — silent failure).
+        let prepareResult: Awaited<ReturnType<typeof session.prepare>>;
+        try {
+          prepareResult = await session.prepare(cycleId, [], localOpts.depth, { force });
+        } catch (prepareErr) {
+          const msg = prepareErr instanceof Error ? prepareErr.message : String(prepareErr);
+          if (ctx.globalOpts.json) {
+            console.log(JSON.stringify({ synthesisProposals: [], error: msg }, null, 2));
+          } else {
+            console.error(`Error: cooldown prepare failed: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
 
         if (!ctx.globalOpts.json) {
           if (prepareResult.incompleteRuns && prepareResult.incompleteRuns.length > 0) {
@@ -744,11 +757,9 @@ export function registerCycleCommands(parent: Command): void {
         } catch (err) {
           const msg = `claude synthesis failed: ${err instanceof Error ? err.message : String(err)}`;
           synthesisError = msg;
-          if (ctx.globalOpts.json) {
-            logger.warn(`--yolo synthesis failure: ${msg}. Completing without proposals.`);
-          } else {
-            console.warn(`Warning: ${msg}. Completing without proposals.`);
-          }
+          // Both modes surface the error — non-JSON to stderr, JSON carries it in the
+          // synthesisError field of the output object (emitted below after complete()).
+          console.warn(`Warning: --yolo synthesis failure: ${msg}. Completing without proposals.`);
         }
 
         // Apply only high-confidence proposals (confidence > 0.8)
@@ -756,7 +767,23 @@ export function registerCycleCommands(parent: Command): void {
           .filter((p) => p.confidence > 0.8)
           .map((p) => p.id);
 
-        const yoloResult = await session.complete(cycleId, synthesisInputId, highConfidenceIds);
+        let yoloResult: Awaited<ReturnType<typeof session.complete>>;
+        try {
+          yoloResult = await session.complete(cycleId, synthesisInputId, highConfidenceIds);
+        } catch (completeErr) {
+          const msg = completeErr instanceof Error ? completeErr.message : String(completeErr);
+          if (ctx.globalOpts.json) {
+            console.log(JSON.stringify({
+              synthesisProposals: [],
+              error: msg,
+              ...(synthesisError !== undefined ? { synthesisError } : {}),
+            }, null, 2));
+          } else {
+            console.error(`Error: cooldown complete failed: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
 
         // Fire-and-forget belt discovery hook
         ProjectStateUpdater.markDiscovery(join(ctx.kataDir, 'project-state.json'), 'completedFirstCycleCooldown');


### PR DESCRIPTION
## Summary

- **#257**: `kata cooldown --yolo --json` produced empty stdout when `session.prepare()` or `session.complete()` threw — the outer `withCommandContext` error handler only wrote to stderr. Fixed by wrapping both calls in explicit try/catch blocks that emit a valid JSON error object (`{"synthesisProposals":[],"error":"..."}`) to stdout on failure.
- **#227**: Synthesis subprocess failure was routed through `logger.warn` (stderr only) in `--json` mode, providing no visible signal. Changed to `console.warn` so both modes surface the error consistently. The `synthesisError` field in the JSON output was already correct; this unifies the non-JSON path.
- Removed now-unused `logger` import from `cycle.ts`.

## What changed

`src/cli/commands/cycle.ts` — `--yolo` block in `kata cooldown`:
- `session.prepare()` wrapped in try/catch: JSON mode emits `{synthesisProposals:[], error}`, non-JSON emits `console.error`
- `session.complete()` wrapped in try/catch: same pattern, preserves `synthesisError` in JSON when synthesis also failed
- Synthesis-failure `logger.warn` → `console.warn` (both modes surface the warning)

## Test plan

- [x] `--yolo --json emits valid JSON with synthesisProposals key when claude is unavailable` — verifies `synthesisProposals: []`, `report`, and `synthesisError` present in JSON output when synthesis fails
- [x] `--yolo non-JSON mode surfaces synthesis failure via console.warn` — verifies `console.warn` carries the synthesis failure message
- [x] All 3019 tests pass (`npm test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (one pre-existing warning in unrelated file)

Closes #257
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)