### PR TITLE
feat: three-part diary — rawDataSummary, agentPerspective, humanPerspective (closes #218)

### DIFF
--- a/src/domain/types/dojo.ts
+++ b/src/domain/types/dojo.ts
@@ -15,6 +15,16 @@ export const DojoDiaryEntrySchema = z.object({
   openQuestions: z.array(z.string()).default([]),
   mood: DojoMood.optional(),
   tags: z.array(z.string()).default([]),
+  /**
+   * Three-part diary fields (#218).
+   * All optional for backward compatibility with existing diary entries.
+   */
+  /** Part 1 — deterministic extraction of all cycle data (observations, decisions, gaps, outcomes). */
+  rawDataSummary: z.string().optional(),
+  /** Part 2 — sensei narrative reflection / synthesis proposals summary. Absent in --prepare mode. */
+  agentPerspective: z.string().optional(),
+  /** Part 3 — human input captured during collaborative cooldown. Absent in --yolo mode. */
+  humanPerspective: z.string().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime().optional(),
 });

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -234,7 +234,7 @@ export class CooldownSession {
    *
    * @param force When true, skips the incomplete-run guard and proceeds even if runs are in-progress.
    */
-  async run(cycleId: string, betOutcomes: BetOutcomeRecord[] = [], { force = false }: { force?: boolean } = {}): Promise<CooldownSessionResult> {
+  async run(cycleId: string, betOutcomes: BetOutcomeRecord[] = [], { force = false, humanPerspective }: { force?: boolean; humanPerspective?: string } = {}): Promise<CooldownSessionResult> {
     // 0. Check for incomplete runs before any state mutation
     const incompleteRuns = this.checkIncompleteRuns(cycleId);
     if (incompleteRuns.length > 0 && !force) {
@@ -339,6 +339,7 @@ export class CooldownSession {
           runSummaries,
           learningsCaptured,
           ruleSuggestions,
+          humanPerspective,
         });
       }
 
@@ -551,6 +552,9 @@ export class CooldownSession {
         runSummaries,
         learningsCaptured: 0,
         ruleSuggestions,
+        agentPerspective: synthesisProposals && synthesisProposals.length > 0
+          ? CooldownSession.buildAgentPerspectiveFromProposals(synthesisProposals)
+          : undefined,
       });
     }
 
@@ -994,14 +998,59 @@ export class CooldownSession {
     runSummaries?: RunSummary[];
     learningsCaptured: number;
     ruleSuggestions?: RuleSuggestion[];
+    /** Part 2 — synthesis proposals summary or sensei reflection. */
+    agentPerspective?: string;
+    /** Part 3 — human input captured during collaborative cooldown. */
+    humanPerspective?: string;
   }): void {
     try {
       const diaryDir = join(this.deps.dojoDir!, 'diary');
       const store = new DiaryStore(diaryDir);
       const writer = new DiaryWriter(store);
-      writer.write(input);
+      writer.write({
+        ...input,
+        agentPerspective: input.agentPerspective,
+        humanPerspective: input.humanPerspective,
+      });
     } catch (err) {
       logger.warn(`Failed to write dojo diary entry: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  /**
+   * Build a text summary of synthesis proposals for use as the diary's agentPerspective.
+   * Returns undefined when there are no proposals.
+   */
+  static buildAgentPerspectiveFromProposals(proposals: SynthesisProposal[]): string | undefined {
+    if (proposals.length === 0) return undefined;
+
+    const lines: string[] = ['## Agent Perspective (Synthesis)'];
+    lines.push('');
+
+    for (const p of proposals) {
+      switch (p.type) {
+        case 'new-learning':
+          lines.push(`**New learning** [${p.proposedTier}/${p.proposedCategory}] (confidence: ${p.confidence.toFixed(2)}):`);
+          lines.push(`  ${p.proposedContent}`);
+          break;
+        case 'update-learning':
+          lines.push(`**Updated learning** (confidence delta: ${p.confidenceDelta > 0 ? '+' : ''}${p.confidenceDelta.toFixed(2)}):`);
+          lines.push(`  ${p.proposedContent}`);
+          break;
+        case 'promote':
+          lines.push(`**Promoted learning** to ${p.toTier} tier.`);
+          break;
+        case 'archive':
+          lines.push(`**Archived learning**: ${p.reason}`);
+          break;
+        case 'methodology-recommendation':
+          lines.push(`**Methodology recommendation** (${p.area}):`);
+          lines.push(`  ${p.recommendation}`);
+          break;
+      }
+      lines.push('');
+    }
+
+    return lines.join('\n').trimEnd();
   }
 }

--- a/src/features/dojo/diary-writer.test.ts
+++ b/src/features/dojo/diary-writer.test.ts
@@ -492,4 +492,86 @@ describe('DiaryWriter', () => {
       expect(entry.createdAt).toBeDefined();
     });
   });
+
+  describe('three-part diary (#218)', () => {
+    it('populates rawDataSummary with bet outcomes section', () => {
+      const input = makeInput({
+        betOutcomes: [
+          { betId: 'aaa', outcome: 'complete' },
+          { betId: 'bbb', outcome: 'partial', notes: 'ran out of time' },
+        ],
+        proposals: [],
+        learningsCaptured: 0,
+      });
+      const entry = writer.write(input);
+      expect(entry.rawDataSummary).toBeDefined();
+      expect(entry.rawDataSummary).toContain('Bet Outcomes');
+      expect(entry.rawDataSummary).toContain('[complete]');
+      expect(entry.rawDataSummary).toContain('[partial]');
+      expect(entry.rawDataSummary).toContain('ran out of time');
+      expect(entry.rawDataSummary).toContain('Completion rate: 1/2');
+    });
+
+    it('rawDataSummary includes run gap data from runSummaries', () => {
+      const input = makeInput({
+        betOutcomes: [],
+        proposals: [],
+        learningsCaptured: 0,
+        runSummaries: [
+          makeRunSummary({
+            gapsBySeverity: { low: 1, medium: 2, high: 3 },
+            stageDetails: [{ category: 'build', selectedFlavors: [], gaps: [] }],
+          }),
+        ],
+      });
+      const entry = writer.write(input);
+      expect(entry.rawDataSummary).toContain('3 high');
+      expect(entry.rawDataSummary).toContain('build');
+    });
+
+    it('rawDataSummary includes learning and proposal counts', () => {
+      const input = makeInput({
+        betOutcomes: [],
+        proposals: [
+          { description: 'Refactor the cycle manager', priority: 'high', type: 'improvement', source: 'gap-analysis', rationale: 'high gap count' },
+        ],
+        learningsCaptured: 5,
+      });
+      const entry = writer.write(input);
+      expect(entry.rawDataSummary).toContain('Learnings captured: 5');
+      expect(entry.rawDataSummary).toContain('[high] Refactor the cycle manager');
+    });
+
+    it('stores agentPerspective when provided', () => {
+      const input = makeInput({ betOutcomes: [], proposals: [], learningsCaptured: 0, agentPerspective: 'This cycle showed strong execution discipline.' });
+      const entry = writer.write(input);
+      expect(entry.agentPerspective).toBe('This cycle showed strong execution discipline.');
+    });
+
+    it('stores humanPerspective when provided', () => {
+      const input = makeInput({ betOutcomes: [], proposals: [], learningsCaptured: 0, humanPerspective: 'Felt productive but the review stage was rushed.' });
+      const entry = writer.write(input);
+      expect(entry.humanPerspective).toBe('Felt productive but the review stage was rushed.');
+    });
+
+    it('agentPerspective and humanPerspective are undefined when not provided', () => {
+      const input = makeInput({ betOutcomes: [], proposals: [], learningsCaptured: 0 });
+      const entry = writer.write(input);
+      expect(entry.agentPerspective).toBeUndefined();
+      expect(entry.humanPerspective).toBeUndefined();
+    });
+
+    it('buildRawDataSummary is exported and callable directly', () => {
+      const writerInstance = new DiaryWriter(store);
+      const summary = writerInstance.buildRawDataSummary({
+        cycleId: 'test-cycle',
+        cycleName: 'Test Cycle',
+        betOutcomes: [{ betId: 'x', outcome: 'complete' }],
+        proposals: [],
+        learningsCaptured: 1,
+      });
+      expect(summary).toContain('Test Cycle');
+      expect(summary).toContain('[complete]');
+    });
+  });
 });

--- a/src/features/dojo/diary-writer.ts
+++ b/src/features/dojo/diary-writer.ts
@@ -15,12 +15,17 @@ export interface DiaryWriterInput {
   runSummaries?: RunSummary[];
   learningsCaptured: number;
   ruleSuggestions?: RuleSuggestion[];
+  /** Part 2 — sensei narrative or synthesis summary. Absent in --prepare mode. */
+  agentPerspective?: string;
+  /** Part 3 — human input captured during collaborative cooldown. Absent in --yolo mode. */
+  humanPerspective?: string;
 }
 
 export class DiaryWriter {
   constructor(private readonly store: DiaryStore) {}
 
   write(input: DiaryWriterInput): DojoDiaryEntry {
+    const rawDataSummary = this.buildRawDataSummary(input);
     const narrative = input.narrative ?? this.generateNarrative(input);
     const wins = this.extractWins(input);
     const painPoints = this.extractPainPoints(input);
@@ -38,12 +43,97 @@ export class DiaryWriter {
       openQuestions,
       mood,
       tags,
+      rawDataSummary,
+      agentPerspective: input.agentPerspective,
+      humanPerspective: input.humanPerspective,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
 
     this.store.write(entry);
     return entry;
+  }
+
+  /**
+   * Build Part 1 of the three-part diary: a deterministic structured summary
+   * of all cycle data — observations, decisions, gaps, bet outcomes, learnings.
+   * This is the factual foundation; no interpretation.
+   */
+  buildRawDataSummary(input: DiaryWriterInput): string {
+    const lines: string[] = [];
+    const name = input.cycleName ?? input.cycleId;
+
+    lines.push(`## Cycle: ${name}`);
+    lines.push('');
+
+    // Bet outcomes
+    lines.push('### Bet Outcomes');
+    if (input.betOutcomes.length === 0) {
+      lines.push('No bets recorded.');
+    } else {
+      for (const bet of input.betOutcomes) {
+        const icon = bet.outcome === 'complete' ? '✓' : bet.outcome === 'partial' ? '~' : bet.outcome === 'abandoned' ? '✗' : '·';
+        const notes = bet.notes ? ` — ${bet.notes}` : '';
+        lines.push(`  ${icon} [${bet.outcome}] bet ${bet.betId.slice(0, 8)}${notes}`);
+      }
+      const complete = input.betOutcomes.filter((b) => b.outcome === 'complete').length;
+      lines.push(`  Completion rate: ${complete}/${input.betOutcomes.length} bets (${Math.round((complete / input.betOutcomes.length) * 100)}%)`);
+    }
+
+    // Per-run data from runSummaries
+    if (input.runSummaries && input.runSummaries.length > 0) {
+      lines.push('');
+      lines.push('### Run Data');
+      for (const summary of input.runSummaries) {
+        lines.push(`  Run ${summary.runId.slice(0, 8)}:`);
+
+        // Gaps by severity
+        const { high, medium, low } = summary.gapsBySeverity;
+        if (high + medium + low > 0) {
+          lines.push(`    Gaps: ${high} high, ${medium} medium, ${low} low`);
+        }
+
+        // Stage details
+        if (summary.stageDetails && summary.stageDetails.length > 0) {
+          const stages = summary.stageDetails.map((s) => s.category).join(', ');
+          lines.push(`    Stages: ${stages}`);
+        }
+
+        // Decision quality
+        if (summary.avgConfidence !== null) {
+          lines.push(`    Avg decision confidence: ${(summary.avgConfidence * 100).toFixed(0)}%`);
+        }
+        if (summary.yoloDecisionCount > 0) {
+          lines.push(`    Decisions bypassed with --yolo: ${summary.yoloDecisionCount}`);
+        }
+        if (summary.artifactPaths.length > 0) {
+          lines.push(`    Artifacts: ${summary.artifactPaths.length}`);
+        }
+      }
+    }
+
+    // Learnings captured
+    lines.push('');
+    lines.push('### Intelligence');
+    lines.push(`  Learnings captured: ${input.learningsCaptured}`);
+
+    // Next-cycle proposals
+    if (input.proposals.length > 0) {
+      lines.push(`  Next-cycle proposals: ${input.proposals.length}`);
+      for (const p of input.proposals.slice(0, 5)) {
+        lines.push(`    · [${p.priority}] ${p.description}`);
+      }
+      if (input.proposals.length > 5) {
+        lines.push(`    … and ${input.proposals.length - 5} more`);
+      }
+    }
+
+    // Rule suggestions
+    if (input.ruleSuggestions && input.ruleSuggestions.length > 0) {
+      lines.push(`  Pending rule suggestions: ${input.ruleSuggestions.length}`);
+    }
+
+    return lines.join('\n');
   }
 
   private generateNarrative(input: DiaryWriterInput): string {


### PR DESCRIPTION
## Summary

Implements the three-part structured diary entry from issue #218.

**Part 1 — rawDataSummary** (deterministic): Auto-built by `DiaryWriter` from bet outcomes, run gap data by severity, avg confidence, artifacts, proposals, and learnings. No interpretation — just organized facts.

**Part 2 — agentPerspective**: Populated from synthesis proposals in `--yolo` cooldown. `CooldownSession.buildAgentPerspectiveFromProposals()` formats each applied proposal type into readable narrative.

**Part 3 — humanPerspective**: Accepted via `DiaryWriterInput`. Will be populated by the collaborative cooldown flow (#219).

## Schema

All three fields are `optional` — backward compatible with existing diary entries.

## Test plan
- [x] 34 tests pass in `diary-writer.test.ts` (7 new)
- [x] Full suite: 3033 tests pass across 147 files
- [x] `rawDataSummary` contains bet outcomes, gap data, learning counts, proposals
- [x] `agentPerspective` / `humanPerspective` round-trip through schema
- [x] Non-breaking: existing tests pass without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)