### PR TITLE
feat: collaborative cooldown reflection prompt in non-yolo mode (#219)

### DIFF
--- a/src/cli/commands/cycle.test.ts
+++ b/src/cli/commands/cycle.test.ts
@@ -603,9 +603,9 @@ describe('registerCycleCommands', () => {
       const _betId = updatedCycle.bets[0]!.id;
 
       // Mock inquirer prompts
-      const { select, input: _input } = await import('@inquirer/prompts');
+      const { select, input } = await import('@inquirer/prompts');
       (select as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce('complete');
-      // input should not be called for complete outcome (no notes prompt)
+      (input as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(''); // human perspective — skip
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', '--cwd', baseDir, 'cooldown', cycle.id]);
@@ -636,6 +636,7 @@ describe('registerCycleCommands', () => {
       const { select, input } = await import('@inquirer/prompts');
       (select as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce('partial');
       (input as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce('Half done');
+      (input as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(''); // human perspective — skip
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', '--cwd', baseDir, 'cooldown', cycle.id]);

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -856,7 +856,34 @@ export function registerCycleCommands(parent: Command): void {
         }
       }
 
-      const result = await session.run(cycleId, betOutcomes, { force });
+      // --- Collaborative reflection: ask human for their perspective (#219) ---
+      let humanPerspective: string | undefined;
+      if (!localOpts.skipPrompts) {
+        const { input: inquirerInput } = await import('@inquirer/prompts');
+
+        // Show a brief cycle summary before asking for reflection
+        const previewReport = manager.generateCooldown(cycleId);
+        const complete = previewReport.bets.filter((b) => b.outcome === 'complete').length;
+        const total = previewReport.bets.length;
+
+        console.log('');
+        console.log('--- Collaborative Reflection ---');
+        if (total > 0) {
+          console.log(`Cycle summary: ${complete}/${total} bets complete (${previewReport.completionRate.toFixed(0)}%)`);
+        }
+        console.log('');
+        console.log('Your perspective helps make the diary entry meaningful for future dojo sessions.');
+
+        const rawPerspective = await inquirerInput({
+          message: 'How did this cycle feel? Any observations the data missed? (Enter to skip)',
+          default: '',
+        });
+
+        humanPerspective = rawPerspective.trim() || undefined;
+        console.log('');
+      }
+
+      const result = await session.run(cycleId, betOutcomes, { force, humanPerspective });
 
       // Fire-and-forget belt discovery hook
       ProjectStateUpdater.markDiscovery(join(ctx.kataDir, 'project-state.json'), 'completedFirstCycleCooldown');


### PR DESCRIPTION
## Summary
- Adds interactive human perspective prompt in `kata cooldown` after bet outcome collection
- Shows cycle summary (X/Y bets complete, completion %) before the prompt
- Skipped automatically in `--skip-prompts` and `--yolo` modes
- `humanPerspective` flows through `session.run()` → `writeDiaryEntry()` → `DojoDiaryEntry`

## Changes
- `src/cli/commands/cycle.ts` — collaborative reflection block with `@inquirer/prompts` `input` call
- `src/features/cycle-management/cooldown-session.ts` — `humanPerspective?` param on `run()`
- `src/features/dojo/diary-writer.ts` — `humanPerspective?` on `DiaryWriterInput`, passed to schema
- `src/domain/types/dojo.ts` — `humanPerspective: z.string().optional()` field on `DojoDiaryEntrySchema`
- `src/cli/commands/cycle.test.ts` — mock `input` for human perspective in interactive tests

## Test plan
- [x] 40 tests in `cycle.test.ts` all pass
- [x] Interactive tests mock `input` for the new human perspective prompt
- [x] `--skip-prompts` and `--yolo` paths unaffected

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collaborative reflection prompt during the cooldown workflow that displays a cycle summary and allows users to optionally provide their observations before execution.

* **Tests**
  * Updated test fixtures to support the new human perspective prompt interaction within the cooldown process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->