### PR TITLE
feat: observation quality guide in agent context + agent-override friction

### DIFF
--- a/src/domain/types/observation.ts
+++ b/src/domain/types/observation.ts
@@ -42,11 +42,12 @@ const PredictionObservationSchema = ObservationBaseSchema.extend({
 // ---------------------------------------------------------------------------
 
 export const FrictionTaxonomy = z.enum([
-  'stale-learning',
-  'config-drift',
-  'convention-clash',
-  'tool-mismatch',
-  'scope-creep',
+  'stale-learning',   // Agent's expected pattern was outdated or wrong in this context
+  'config-drift',     // Actual env/files/settings don't match what's documented or expected
+  'convention-clash', // Established code convention conflicts with how you'd naturally approach it
+  'tool-mismatch',    // Available tool required workarounds — not quite right for the job
+  'scope-creep',      // Work expanded beyond the original bet boundary during execution
+  'agent-override',   // User directed a different approach from what the agent would have chosen
 ]);
 
 export type FrictionTaxonomy = z.infer<typeof FrictionTaxonomy>;

--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -310,8 +310,10 @@ describe('SessionExecutionBridge', () => {
       expect(context).toContain('### Record as you work');
       // kansatsu: positional type + content, --run flag (not --run-id)
       expect(context).toContain(`kata kansatsu record <type> "..." --run ${prepared.runId}`);
-      // valid types listed in context comment
-      expect(context).toContain('decision | prediction | friction | gap | outcome | assumption | insight');
+      // observation types and quality guide present
+      expect(context).toContain('**Observation types**');
+      expect(context).toContain('**Friction taxonomy**');
+      expect(context).toContain('**Quality bar**');
       // maki: positional name + path, --run flag
       expect(context).toContain(`kata maki record <name> <path> --run ${prepared.runId}`);
       // kime: named flags only, --run flag (not --run-id)

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -179,12 +179,32 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
 
     // Record as you work
     lines.push('### Record as you work');
-    lines.push('Use these commands at natural checkpoints (not after every line of code):');
+    lines.push('Use these commands at natural checkpoints — when a decision matters, when something surprises you, when you hit resistance:');
     lines.push('');
-    lines.push('  # kansatsu record — type is one of: decision | prediction | friction | gap | outcome | assumption | insight');
-    lines.push(`  kata kansatsu record <type> "..." --run ${prepared.runId} --severity info`);
+    lines.push(`  kata kansatsu record <type> "..." --run ${prepared.runId}`);
     lines.push(`  kata maki record <name> <path> --run ${prepared.runId}`);
     lines.push(`  kata kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
+    lines.push('');
+    lines.push('**Observation types** — pick the most specific:');
+    lines.push('  decision    — a choice between real alternatives; always include WHY you chose this path');
+    lines.push('  prediction  — a testable bet about future behavior (state what would falsify it)');
+    lines.push('  assumption  — something you are treating as true but have not verified');
+    lines.push('  friction    — something that slowed you down; requires --taxonomy (see below)');
+    lines.push('  gap         — missing capability, coverage, or information; requires --severity critical|major|minor');
+    lines.push('  outcome     — factual result after a decision or prediction resolves');
+    lines.push('  insight     — non-obvious learning that would change your approach in a similar situation');
+    lines.push('');
+    lines.push('**Friction taxonomy** (--taxonomy <value>):');
+    lines.push('  stale-learning   — your expected pattern was outdated or wrong in this context');
+    lines.push('  config-drift     — actual env/files/settings do not match documented expectations');
+    lines.push('  convention-clash — established code convention conflicts with the natural approach');
+    lines.push('  tool-mismatch    — available tool required workarounds; not quite right for the job');
+    lines.push('  scope-creep      — work expanded beyond the original bet boundary during execution');
+    lines.push('  agent-override   — user directed a different approach from what you would have chosen');
+    lines.push('');
+    lines.push('**Quality bar** — ask: would a future agent reading this understand what happened and why?');
+    lines.push('  weak:   "Features already in main, issues can be closed"');
+    lines.push('  strong: "Bets silently become redundant when issues stay open after merging — triage needs a closed-issue pre-flight"');
     lines.push('');
 
     // Injected learnings


### PR DESCRIPTION
## Summary
- Replaces the sparse one-liner kansatsu hint in `formatAgentContext()` with a structured quality guide covering all 7 observation types, all 6 friction taxonomy values, and a weak-vs-strong example pair
- Adds `agent-override` to `FrictionTaxonomy` — captures the case where the user directs a different approach from what the agent would have chosen (previously no taxonomy value existed for agent/user preference divergence)
- Fixes the misleading `--severity info` flag in the old agent context (severity only applies to `gap` type, valid values are `critical|major|minor`)

## Changes
- `src/domain/types/observation.ts` — `agent-override` added to `FrictionTaxonomy` with inline doc comment for each value
- `src/infrastructure/execution/session-bridge.ts` — `formatAgentContext()` kansatsu section rewritten with full type + taxonomy guide and quality bar
- `src/infrastructure/execution/session-bridge.test.ts` — updated assertion to check for guide sections rather than old type-list string

## Test plan
- [x] 59 tests pass (`session-bridge.test.ts` + `observe.test.ts`)
- [x] `agent-override` appears in the error message for missing `--taxonomy` (observe.test.ts stderr confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)