### PR TITLE
feat: --explain flag for kata kiai flavor scoring details (#221)

### DIFF
--- a/src/cli/commands/execute.test.ts
+++ b/src/cli/commands/execute.test.ts
@@ -539,6 +539,186 @@ describe('registerExecuteCommands', () => {
     });
   });
 
+  // ---- --explain ----
+
+  describe('--explain', () => {
+    it('registers --explain option on the execute command', () => {
+      const program = createProgram();
+      const executeCmd = program.commands.find((c) => c.name() === 'execute');
+      expect(executeCmd).toBeDefined();
+      const explainOpt = executeCmd!.options.find((o) => o.long === '--explain');
+      expect(explainOpt).toBeDefined();
+    });
+
+    it('prints flavor scoring breakdown for a single stage when --explain is set', async () => {
+      mockRunStage.mockResolvedValue({
+        ...makeSingleResult('build'),
+        matchReports: [
+          {
+            flavorName: 'typescript-tdd',
+            score: 0.87,
+            keywordHits: 3,
+            ruleAdjustments: 0,
+            learningBoost: 0,
+            reasoning: 'Score 0.87: 3 keyword hit(s), learning boost 0.00, rule adj 0.00.',
+          },
+          {
+            flavorName: 'quick-fix',
+            score: 0.42,
+            keywordHits: 1,
+            ruleAdjustments: 0,
+            learningBoost: 0,
+            reasoning: 'Score 0.42: 1 keyword hit(s), learning boost 0.00, rule adj 0.00.',
+          },
+        ],
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'build', '--explain']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('Flavor scoring for stage: build');
+      expect(output).toContain('typescript-tdd');
+      expect(output).toContain('0.87');
+      expect(output).toContain('<- selected');
+      expect(output).toContain('quick-fix');
+      expect(output).toContain('0.42');
+    });
+
+    it('still prints normal stage output after the explain block', async () => {
+      mockRunStage.mockResolvedValue({
+        ...makeSingleResult('build'),
+        matchReports: [
+          {
+            flavorName: 'typescript-tdd',
+            score: 0.87,
+            keywordHits: 3,
+            ruleAdjustments: 0,
+            learningBoost: 0,
+            reasoning: 'Score 0.87: 3 keyword hit(s).',
+          },
+        ],
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'build', '--explain']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('Stage: build');
+      expect(output).toContain('Selected flavors: typescript-tdd');
+    });
+
+    it('prints scoring breakdown for each stage in a multi-stage pipeline when --explain is set', async () => {
+      mockRunPipeline.mockResolvedValue({
+        stageResults: [
+          {
+            stageCategory: 'research',
+            selectedFlavors: ['deep-dive'],
+            executionMode: 'sequential',
+            stageArtifact: { name: 'research-synthesis', content: 'output', timestamp: new Date().toISOString() },
+            decisions: [],
+            matchReports: [
+              {
+                flavorName: 'deep-dive',
+                score: 0.75,
+                keywordHits: 2,
+                ruleAdjustments: 0,
+                learningBoost: 0,
+                reasoning: 'Score 0.75: 2 keyword hit(s).',
+              },
+            ],
+          },
+          {
+            stageCategory: 'build',
+            selectedFlavors: ['typescript-tdd'],
+            executionMode: 'sequential',
+            stageArtifact: { name: 'build-synthesis', content: 'output', timestamp: new Date().toISOString() },
+            decisions: [],
+            matchReports: [
+              {
+                flavorName: 'typescript-tdd',
+                score: 0.90,
+                keywordHits: 4,
+                ruleAdjustments: 0.1,
+                learningBoost: 0.1,
+                reasoning: 'Score 0.90: 4 keyword hit(s), learning boost 0.10, rule adj 0.10.',
+              },
+            ],
+          },
+        ],
+        pipelineReflection: { overallQuality: 'good', learnings: [] },
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'research', 'build', '--explain']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('Flavor scoring for stage: research');
+      expect(output).toContain('Flavor scoring for stage: build');
+      expect(output).toContain('deep-dive');
+      expect(output).toContain('typescript-tdd');
+    });
+
+    it('prints fallback message when matchReports is absent (pinned/no-vocabulary)', async () => {
+      mockRunStage.mockResolvedValue({
+        ...makeSingleResult('build'),
+        matchReports: undefined,
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'build', '--explain']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('Flavor scoring for stage: build');
+      expect(output).toContain('no scoring data');
+    });
+
+    it('prints learning boost and rule adjustments when non-zero', async () => {
+      mockRunStage.mockResolvedValue({
+        ...makeSingleResult('build'),
+        matchReports: [
+          {
+            flavorName: 'typescript-tdd',
+            score: 0.90,
+            keywordHits: 2,
+            ruleAdjustments: 0.15,
+            learningBoost: 0.10,
+            reasoning: 'Score 0.90: 2 keyword hit(s), learning boost 0.10, rule adj 0.15.',
+          },
+        ],
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'build', '--explain']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('learning boost');
+      expect(output).toContain('rule adjustments');
+    });
+
+    it('does not print explain block when --explain is not set', async () => {
+      mockRunStage.mockResolvedValue({
+        ...makeSingleResult('build'),
+        matchReports: [
+          {
+            flavorName: 'typescript-tdd',
+            score: 0.87,
+            keywordHits: 3,
+            ruleAdjustments: 0,
+            learningBoost: 0,
+            reasoning: 'Score 0.87.',
+          },
+        ],
+      });
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', '--cwd', baseDir, 'execute', 'build']);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).not.toContain('Flavor scoring for stage');
+    });
+  });
+
   // ---- --next flag (Issue #191) ----
 
   describe('--next', () => {

--- a/src/cli/commands/execute.ts
+++ b/src/cli/commands/execute.ts
@@ -324,6 +324,7 @@ export function registerExecuteCommands(program: Command): void {
     .option('--yolo', 'Skip confidence gate checks — all decisions proceed without human approval')
     .option('--bridge-gaps', 'Capture identified gaps as step-tier learnings; block on high-severity gaps')
     .option('--hint <spec>', 'Per-stage flavor hint: stage:flavor1,flavor2[:strategy] — guides orchestrator selection (can be repeated)', collect, [])
+    .option('--explain', 'Print per-flavor scoring breakdown showing why each flavor was scored and which was selected')
     .option('--next', 'Auto-select the first pending bet from the active cycle as the run target')
     .action(withCommandContext(async (ctx, categories: string[]) => {
       const localOpts = ctx.cmd.opts();
@@ -439,6 +440,7 @@ export function registerExecuteCommands(program: Command): void {
         yolo: localOpts.yolo as boolean | undefined,
         bridgeGaps: localOpts.bridgeGaps as boolean | undefined,
         flavorHints: mergedHints,
+        explain: localOpts.explain as boolean | undefined,
       });
     }));
 }
@@ -461,6 +463,60 @@ interface RunOptions {
   bridgeGaps?: boolean;
   /** Parsed flavor hints (from saved kata or --hint flags). */
   flavorHints?: Record<string, FlavorHint>;
+  /** Print flavor scoring breakdown before results. */
+  explain?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Explain formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a per-flavor scoring breakdown for a single stage result.
+ * Prints all scored flavors with their scores, and marks the selected flavor(s).
+ */
+function formatExplain(
+  stageCategory: string,
+  selectedFlavors: readonly string[],
+  matchReports?: Array<{ flavorName: string; score: number; keywordHits: number; ruleAdjustments: number; learningBoost: number; reasoning: string }>,
+): string {
+  const lines: string[] = [];
+  const selectedSet = new Set(selectedFlavors);
+
+  lines.push(`Flavor scoring for stage: ${stageCategory}`);
+
+  if (!matchReports || matchReports.length === 0) {
+    lines.push(`  Selected: ${selectedFlavors.join(', ')} (no scoring data — flavor was pinned or vocabulary unavailable)`);
+    return lines.join('\n');
+  }
+
+  // Sort by score descending
+  const sorted = [...matchReports].sort((a, b) => b.score - a.score);
+
+  lines.push('');
+  lines.push('  Flavor scores:');
+  for (const report of sorted) {
+    const selected = selectedSet.has(report.flavorName) ? '  <- selected' : '';
+    lines.push(`    ${report.flavorName.padEnd(24)}  score: ${report.score.toFixed(2)}${selected}`);
+  }
+
+  lines.push('');
+  lines.push('  Scoring factors:');
+  for (const report of sorted) {
+    if (!selectedSet.has(report.flavorName) && report.score === 0 && sorted[0]!.score > 0) continue;
+    lines.push(`    ${report.flavorName}:`);
+    lines.push(`      keyword hits:      ${report.keywordHits}`);
+    if (report.learningBoost > 0) {
+      lines.push(`      learning boost:    +${report.learningBoost.toFixed(2)}`);
+    }
+    if (report.ruleAdjustments !== 0) {
+      const sign = report.ruleAdjustments > 0 ? '+' : '';
+      lines.push(`      rule adjustments:  ${sign}${report.ruleAdjustments.toFixed(2)}`);
+    }
+    lines.push(`      reasoning:         ${report.reasoning}`);
+  }
+
+  return lines.join('\n');
 }
 
 async function runCategories(
@@ -540,6 +596,10 @@ async function runCategories(
     if (isJson) {
       console.log(JSON.stringify(result, null, 2));
     } else {
+      if (opts.explain) {
+        console.log(formatExplain(result.stageCategory, result.selectedFlavors, result.matchReports));
+        console.log('');
+      }
       console.log(`Stage: ${result.stageCategory}`);
       console.log(`Execution mode: ${result.executionMode}`);
       console.log(`Selected flavors: ${result.selectedFlavors.join(', ')}`);
@@ -582,6 +642,12 @@ async function runCategories(
     if (isJson) {
       console.log(JSON.stringify(result, null, 2));
     } else {
+      if (opts.explain) {
+        for (const stageResult of result.stageResults) {
+          console.log(formatExplain(stageResult.stageCategory, stageResult.selectedFlavors, stageResult.matchReports));
+          console.log('');
+        }
+      }
       console.log(`Pipeline: ${categories.join(' -> ')}`);
       console.log(`Stages completed: ${result.stageResults.length}`);
       console.log(`Overall quality: ${result.pipelineReflection.overallQuality}`);


### PR DESCRIPTION
## Summary

- Adds `--explain` flag to `kata kiai` (and its `execute` alias)
- When set, prints a per-flavor scoring breakdown before the normal stage output
- Works for both single-stage (`kata kiai build --explain`) and multi-stage pipeline (`kata kiai research build --explain`)
- No new scoring data is computed — surfaces `OrchestratorResult.matchReports` already produced by `BaseStageOrchestrator.match()` but previously discarded at the CLI layer

## What scoring data is available

Each `MatchReport` in `matchReports` has:
- `flavorName` — the flavor being scored
- `score` — final score in [0, 1]
- `keywordHits` — vocabulary keyword matches against flavor name/description/bet context
- `ruleAdjustments` — net adjustment from active stage rules (boost/penalize)
- `learningBoost` — additive boost from learnings that mention the flavor
- `reasoning` — human-readable explanation string from the orchestrator

When `matchReports` is absent (flavor was pinned or vocabulary unavailable), a fallback message is shown instead.

## Sample output

```
Flavor scoring for stage: build

  Flavor scores:
    typescript-tdd            score: 0.87  <- selected
    quick-fix                 score: 0.42
    research-only             score: 0.31

  Scoring factors:
    typescript-tdd:
      keyword hits:      3
      reasoning:         Score 0.87: 3 keyword hit(s), learning boost 0.00, rule adj 0.00.
    quick-fix:
      keyword hits:      1
      reasoning:         Score 0.42: 1 keyword hit(s), learning boost 0.00, rule adj 0.00.
    ...

Stage: build
Execution mode: sequential
Selected flavors: typescript-tdd
...
```

## Test plan

- [x] `--explain` option registered on the `execute` command
- [x] Single-stage: prints scoring breakdown with selected marker
- [x] Single-stage: normal output still follows explain block
- [x] Multi-stage: prints scoring breakdown per stage
- [x] Fallback message when `matchReports` is absent
- [x] Learning boost and rule adjustments shown when non-zero
- [x] No explain block when `--explain` not set
- [x] `npm test` — 67/67 `execute.test.ts` tests pass; 1 pre-existing failure in `observation.test.ts` unrelated to this PR
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing warning in unrelated file)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--explain` flag to the execute command that displays detailed flavor scoring breakdowns for each pipeline stage, including keyword match contributions, learning boost effects, rule adjustments, and selection reasoning.

* **Tests**
  * Added comprehensive test coverage for the explain functionality across single and multi-stage scenarios, including fallback messaging when scoring data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->