### PR TITLE
fix: kiai complete updates run.json status so kata watch drops completed runs (#254)

### DIFF
--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -535,6 +535,63 @@ describe('SessionExecutionBridge', () => {
       expect(bet2.outcome).toBe('pending');
     });
 
+    it('should update run.json status to "completed" on success (#254)', () => {
+      const cycle = createCycle(kataDir);
+      const bridge = new SessionExecutionBridge(kataDir);
+      const prepared = bridge.prepare(cycle.bets[0]!.id);
+
+      bridge.complete(prepared.runId, { success: true });
+
+      const runJsonPath = join(kataDir, 'runs', prepared.runId, 'run.json');
+      const run = RunSchema.parse(JSON.parse(readFileSync(runJsonPath, 'utf-8')));
+      expect(run.status).toBe('completed');
+      expect(run.completedAt).toBeTruthy();
+    });
+
+    it('should update run.json status to "failed" on failure (#254)', () => {
+      const cycle = createCycle(kataDir);
+      const bridge = new SessionExecutionBridge(kataDir);
+      const prepared = bridge.prepare(cycle.bets[0]!.id);
+
+      bridge.complete(prepared.runId, { success: false, notes: 'Build failed' });
+
+      const runJsonPath = join(kataDir, 'runs', prepared.runId, 'run.json');
+      const run = RunSchema.parse(JSON.parse(readFileSync(runJsonPath, 'utf-8')));
+      expect(run.status).toBe('failed');
+      expect(run.completedAt).toBeTruthy();
+    });
+
+    it('completed run should NOT appear in listActiveRuns (kata watch drops off) (#254)', () => {
+      const cycle = createCycle(kataDir);
+      const bridge = new SessionExecutionBridge(kataDir);
+      const prepared = bridge.prepare(cycle.bets[0]!.id);
+
+      // Before complete: run should be visible as running
+      const runsDir = join(kataDir, 'runs');
+      const activeBeforeComplete = readdirSync(runsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .filter((e) => {
+          try {
+            const run = RunSchema.parse(JSON.parse(readFileSync(join(runsDir, e.name, 'run.json'), 'utf-8')));
+            return run.status === 'running';
+          } catch { return false; }
+        });
+      expect(activeBeforeComplete.length).toBe(1);
+
+      bridge.complete(prepared.runId, { success: true });
+
+      // After complete: no running runs remain
+      const activeAfterComplete = readdirSync(runsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .filter((e) => {
+          try {
+            const run = RunSchema.parse(JSON.parse(readFileSync(join(runsDir, e.name, 'run.json'), 'utf-8')));
+            return run.status === 'running';
+          } catch { return false; }
+        });
+      expect(activeAfterComplete.length).toBe(0);
+    });
+
     it('should record token usage in history entry', () => {
       const cycle = createCycle(kataDir);
       const bridge = new SessionExecutionBridge(kataDir);

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -17,7 +17,7 @@ import { type Bet } from '@domain/types/bet.js';
 import { StageCategorySchema } from '@domain/types/stage.js';
 import { z } from 'zod/v4';
 import { JsonStore } from '@infra/persistence/json-store.js';
-import { createRunTree } from '@infra/persistence/run-store.js';
+import { createRunTree, readRun, writeRun } from '@infra/persistence/run-store.js';
 import { KATA_DIRS } from '@shared/constants/paths.js';
 import { logger } from '@shared/lib/logger.js';
 
@@ -334,6 +334,11 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
     meta.completedAt = completedAt;
     meta.status = result.success ? 'complete' : 'failed';
     this.writeBridgeRunMeta(meta);
+
+    // Update run.json so kata watch drops this run off the active list (#254).
+    // run.json status uses "completed"/"failed" (RunStatusSchema) — not the
+    // BridgeRunMeta values "complete"/"failed".
+    this.updateRunJsonStatus(runId, result.success ? 'completed' : 'failed', completedAt);
 
     // Update the bet outcome in the cycle JSON so CycleManager.generateCooldown()
     // sees correct completion data (fixes #216: 0% completion rate in cooldown).
@@ -672,6 +677,35 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
       // will simply not see this run until the issue is resolved.
       logger.warn('Failed to write run.json for bridge run — kata watch will not see this run.', {
         runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Update run.json status and completedAt after a bridge run completes (#254).
+   *
+   * kata watch filters by `run.status === 'running'`, so setting status to
+   * "completed" or "failed" causes the run to drop off the active list.
+   *
+   * Non-critical: logs a warning on failure but does not abort complete() —
+   * the history entry and bridge-run metadata were already written.
+   */
+  private updateRunJsonStatus(
+    runId: string,
+    status: 'completed' | 'failed',
+    completedAt: string,
+  ): void {
+    try {
+      const runsDir = join(this.kataDir, KATA_DIRS.runs);
+      const run = readRun(runsDir, runId);
+      run.status = status;
+      run.completedAt = completedAt;
+      writeRun(runsDir, run);
+    } catch (err) {
+      logger.warn('Failed to update run.json status after bridge complete — kata watch may still show this run.', {
+        runId,
+        status,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

- `SessionExecutionBridge.complete()` now calls the new private `updateRunJsonStatus()` helper after writing bridge-run metadata
- `updateRunJsonStatus()` reads `run.json` via `readRun()`, sets `status` to `"completed"` or `"failed"` and `completedAt`, then writes it back via `writeRun()`
- `kata watch` (`run-reader.listActiveRuns`) filters with `run.status !== 'running'`, so completed runs immediately drop off the active list

## Root cause

`run.json` was written once in `prepare()` with `status: "running"` and never updated. `kata kiai complete` updated `bridge-runs/<id>.json` but the watch TUI only reads `run.json`.

## Test plan

- [x] `complete()` → run.json status is `"completed"` on success
- [x] `complete()` → run.json status is `"failed"` on failure
- [x] run.json with `status !== "running"` does not appear in `listActiveRuns` simulation
- [x] All 45 session-bridge tests pass
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed run completion status tracking to ensure run metadata accurately reflects completion state and timestamp.
  * Completed runs now properly removed from active runs list.

* **Tests**
  * Added comprehensive tests validating run status updates when runs complete, covering both success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->