### PR TITLE
fix: diary renders bet descriptions instead of IDs or generic text (#302, #303)

### DIFF
--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -139,6 +139,8 @@ export interface BetOutcomeRecord {
   betId: string;
   outcome: 'complete' | 'partial' | 'abandoned';
   notes?: string;
+  /** Human-readable bet description, for display in diary entries. */
+  betDescription?: string;
 }
 
 /**
@@ -339,10 +341,15 @@ export class CooldownSession {
 
       // 8.5. Write dojo diary entry (non-critical — failure never aborts cooldown)
       if (this.deps.dojoDir) {
+        const betDescriptionMap = new Map(cycle.bets.map((b) => [b.id, b.description]));
+        const enrichedBetOutcomes = effectiveBetOutcomes.map((b) => ({
+          ...b,
+          betDescription: b.betDescription ?? betDescriptionMap.get(b.betId),
+        }));
         this.writeDiaryEntry({
           cycleId,
           cycleName: cycle.name,
-          betOutcomes: effectiveBetOutcomes,
+          betOutcomes: enrichedBetOutcomes,
           proposals,
           runSummaries,
           learningsCaptured,
@@ -554,7 +561,7 @@ export class CooldownSession {
     if (this.deps.dojoDir) {
       const effectiveBetOutcomes: BetOutcomeRecord[] = cycle.bets
         .filter((b) => b.outcome !== 'pending')
-        .map((b) => ({ betId: b.id, outcome: b.outcome as BetOutcomeRecord['outcome'], notes: b.outcomeNotes }));
+        .map((b) => ({ betId: b.id, outcome: b.outcome as BetOutcomeRecord['outcome'], notes: b.outcomeNotes, betDescription: b.description }));
       this.writeDiaryEntry({
         cycleId,
         cycleName: cycle.name,

--- a/src/features/dojo/diary-writer.test.ts
+++ b/src/features/dojo/diary-writer.test.ts
@@ -163,6 +163,31 @@ describe('DiaryWriter', () => {
       expect(entry.wins[1]).toBe('Completed bet');
     });
 
+    it('uses betDescription as the win label when provided (#302)', () => {
+      const input = makeInput({
+        betOutcomes: [
+          makeBetOutcome({ outcome: 'complete', betDescription: 'Implement auth flow' }),
+          makeBetOutcome({ outcome: 'complete', betDescription: 'Ship dashboard', notes: 'minor polish needed' }),
+        ],
+      });
+
+      const entry = writer.write(input);
+
+      expect(entry.wins).toHaveLength(2);
+      expect(entry.wins[0]).toBe('Implement auth flow');
+      expect(entry.wins[1]).toBe('Ship dashboard — minor polish needed');
+    });
+
+    it('falls back to "Completed bet" when betDescription is absent (#302)', () => {
+      const input = makeInput({
+        betOutcomes: [makeBetOutcome({ outcome: 'complete' })],
+      });
+
+      const entry = writer.write(input);
+
+      expect(entry.wins[0]).toBe('Completed bet');
+    });
+
     it('returns empty wins when no bets are complete', () => {
       const input = makeInput({
         betOutcomes: [makeBetOutcome({ outcome: 'partial' })],
@@ -572,6 +597,33 @@ describe('DiaryWriter', () => {
       });
       expect(summary).toContain('Test Cycle');
       expect(summary).toContain('[complete]');
+    });
+
+    it('rawDataSummary uses betDescription instead of short betId (#303)', () => {
+      const betId = crypto.randomUUID();
+      const input = makeInput({
+        betOutcomes: [
+          { betId, outcome: 'complete', betDescription: 'Migrate the auth service' },
+          { betId: crypto.randomUUID(), outcome: 'partial', betDescription: 'Refactor pipeline', notes: 'ran out of time' },
+        ],
+        proposals: [],
+        learningsCaptured: 0,
+      });
+      const entry = writer.write(input);
+      expect(entry.rawDataSummary).toContain('Migrate the auth service');
+      expect(entry.rawDataSummary).toContain('Refactor pipeline');
+      expect(entry.rawDataSummary).not.toContain(betId.slice(0, 8));
+    });
+
+    it('rawDataSummary falls back to short betId when betDescription is absent (#303)', () => {
+      const betId = 'aaa-bbb-ccc-ddd';
+      const input = makeInput({
+        betOutcomes: [{ betId, outcome: 'complete' }],
+        proposals: [],
+        learningsCaptured: 0,
+      });
+      const entry = writer.write(input);
+      expect(entry.rawDataSummary).toContain(`bet ${betId.slice(0, 8)}`);
     });
   });
 });

--- a/src/features/dojo/diary-writer.ts
+++ b/src/features/dojo/diary-writer.ts
@@ -73,8 +73,9 @@ export class DiaryWriter {
     } else {
       for (const bet of input.betOutcomes) {
         const icon = bet.outcome === 'complete' ? '✓' : bet.outcome === 'partial' ? '~' : bet.outcome === 'abandoned' ? '✗' : '·';
+        const label = bet.betDescription ?? `bet ${bet.betId.slice(0, 8)}`;
         const notes = bet.notes ? ` — ${bet.notes}` : '';
-        lines.push(`  ${icon} [${bet.outcome}] bet ${bet.betId.slice(0, 8)}${notes}`);
+        lines.push(`  ${icon} [${bet.outcome}] ${label}${notes}`);
       }
       const complete = input.betOutcomes.filter((b) => b.outcome === 'complete').length;
       lines.push(`  Completion rate: ${complete}/${input.betOutcomes.length} bets (${Math.round((complete / input.betOutcomes.length) * 100)}%)`);
@@ -158,8 +159,9 @@ export class DiaryWriter {
     return input.betOutcomes
       .filter((b) => b.outcome === 'complete')
       .map((b) => {
+        const label = b.betDescription ?? 'Completed bet';
         const notes = b.notes ? ` — ${b.notes}` : '';
-        return `Completed bet${notes}`;
+        return `${label}${notes}`;
       });
   }
 


### PR DESCRIPTION
## Summary

- #302: `extractWins()` was hardcoded to `'Completed bet'` — now uses `betDescription` when present
- #303: `buildRawDataSummary()` rendered short bet IDs — now uses `betDescription` when present

## Root cause

`BetOutcomeRecord` had no `betDescription` field. Both cooldown call sites that built records from `cycle.bets` never passed descriptions through.

## Changes

- `BetOutcomeRecord` gains optional `betDescription?: string`
- `CooldownSession.run()`: enriches effective bet outcomes with descriptions from `cycle.bets` before `writeDiaryEntry`
- `CooldownSession.complete()`: includes `betDescription: b.description` in outcome map built from `cycle.bets`
- `DiaryWriter.extractWins()`: uses `betDescription ?? 'Completed bet'` as label
- `DiaryWriter.buildRawDataSummary()`: uses `betDescription ?? 'bet <short-id>'` as label

## Test plan
- diary-writer: 38 tests pass (4 new for #302/#303)
- cooldown-session: 57 tests pass
- typecheck: clean, lint: 0 errors

Generated with Claude Code