### PR TITLE
fix: auto-attribute katakaId from run.json in kime/maki record

### DIFF
--- a/src/cli/commands/artifact.test.ts
+++ b/src/cli/commands/artifact.test.ts
@@ -377,4 +377,80 @@ describe('registerArtifactCommands — artifact record', () => {
 
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --type'));
   });
+
+  it('auto-populates katakaId from run.json when --kataka is not provided', async () => {
+    const katakaId = randomUUID();
+    const run = makeRun({ katakaId });
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'context.md');
+    writeFileSync(srcFile, '# Context', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'technical-research',
+      '--step', 'gather-context',
+      '--file', srcFile,
+      '--summary', 'Context output',
+    ]);
+
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBe(katakaId);
+  });
+
+  it('explicit --kataka flag overrides katakaId from run.json', async () => {
+    const runKatakaId = randomUUID();
+    const explicitKatakaId = randomUUID();
+    const run = makeRun({ katakaId: runKatakaId });
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'context.md');
+    writeFileSync(srcFile, '# Context', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'technical-research',
+      '--step', 'gather-context',
+      '--file', srcFile,
+      '--summary', 'Context output',
+      '--kataka', explicitKatakaId,
+    ]);
+
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBe(explicitKatakaId);
+  });
+
+  it('leaves katakaId undefined when run.json has no katakaId and --kataka is not provided', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const srcFile = join(baseDir, 'context.md');
+    writeFileSync(srcFile, '# Context', 'utf-8');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'artifact', 'record', run.id,
+      '--stage', 'research',
+      '--flavor', 'technical-research',
+      '--step', 'gather-context',
+      '--file', srcFile,
+      '--summary', 'Context output',
+    ]);
+
+    const runIndexPath = join(runsDir, run.id, 'artifact-index.jsonl');
+    const entries = JsonlStore.readAll(runIndexPath, ArtifactIndexEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBeUndefined();
+  });
 });

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -34,6 +34,7 @@ export function registerArtifactCommands(parent: Command): void {
     .requiredOption('--file <path>', 'Path to the source artifact file')
     .requiredOption('--summary <description>', 'Short summary of the artifact content')
     .option('--type <type>', 'Artifact type: "artifact" (default) or "synthesis"', 'artifact')
+    .option('--kataka <id>', 'Kataka (agent) ID recording this artifact')
     .action(withCommandContext(async (ctx, runId: string) => {
       const localOpts = ctx.cmd.opts();
       const runsDir = kataDirPath(ctx.kataDir, 'runs');
@@ -74,6 +75,12 @@ export function registerArtifactCommands(parent: Command): void {
       }
 
       const paths = runPaths(runsDir, runId);
+
+      // Auto-populate katakaId from run.json if not explicitly provided
+      let katakaId: string | undefined = localOpts.kataka as string | undefined;
+      if (!katakaId) {
+        katakaId = run.katakaId;
+      }
       const flavor = (localOpts.flavor as string | undefined) ?? null;
 
       // Synthesis artifacts are always named synthesis.md regardless of source filename
@@ -135,6 +142,7 @@ export function registerArtifactCommands(parent: Command): void {
         summary: localOpts.summary as string,
         type: artifactType as 'artifact' | 'synthesis',
         recordedAt: new Date().toISOString(),
+        ...(katakaId ? { katakaId } : {}),
       };
 
       // Append to flavor-level (or stage-level) artifact-index.jsonl

--- a/src/cli/commands/decision.test.ts
+++ b/src/cli/commands/decision.test.ts
@@ -484,6 +484,70 @@ describe('registerDecisionCommands — decision record', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('context'));
   });
 
+  it('auto-populates katakaId from run.json when --kataka is not provided', async () => {
+    const katakaId = randomUUID();
+    const run = makeRun({ katakaId });
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--selected', 'technical-research',
+      '--confidence', '0.9',
+    ]);
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBe(katakaId);
+  });
+
+  it('explicit --kataka flag overrides katakaId from run.json', async () => {
+    const runKatakaId = randomUUID();
+    const explicitKatakaId = randomUUID();
+    const run = makeRun({ katakaId: runKatakaId });
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--selected', 'technical-research',
+      '--confidence', '0.9',
+      '--kataka', explicitKatakaId,
+    ]);
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBe(explicitKatakaId);
+  });
+
+  it('leaves katakaId undefined when run.json has no katakaId and --kataka is not provided', async () => {
+    const run = makeRun();
+    createRunTree(runsDir, run);
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'test', '--json', '--cwd', baseDir,
+      'decision', 'record', run.id,
+      '--stage', 'research',
+      '--type', 'flavor-selection',
+      '--selected', 'technical-research',
+      '--confidence', '0.9',
+    ]);
+
+    const decisionsPath = join(runsDir, run.id, 'decisions.jsonl');
+    const entries = JsonlStore.readAll(decisionsPath, DecisionEntrySchema);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.katakaId).toBeUndefined();
+  });
+
   it('does not create a second gate when pendingGate already exists', async () => {
     const run = makeRun();
     createRunTree(runsDir, run);

--- a/src/cli/commands/decision.ts
+++ b/src/cli/commands/decision.ts
@@ -37,6 +37,7 @@ export function registerDecisionCommands(parent: Command): void {
     .option('--confidence <number>', 'Confidence in the selection [0-1] (default: 1.0)', parseFloat)
     .option('--reasoning <text>', 'Orchestrator\'s reasoning for the selection')
     .option('--yolo', 'Bypass the confidence gate even if confidence is below threshold')
+    .option('--kataka <id>', 'Kataka (agent) ID recording this decision')
     .action(withCommandContext(async (ctx, runId: string) => {
       const localOpts = ctx.cmd.opts();
       const runsDir = kataDirPath(ctx.kataDir, 'runs');
@@ -104,9 +105,16 @@ export function registerDecisionCommands(parent: Command): void {
       }
 
       // Validate run exists
-      readRun(runsDir, runId);
+      const runData = readRun(runsDir, runId);
 
       const paths = runPaths(runsDir, runId);
+
+      // Auto-populate katakaId from run.json if not explicitly provided
+      let katakaId: string | undefined = localOpts.kataka as string | undefined;
+      if (!katakaId) {
+        katakaId = runData.katakaId;
+      }
+
       const id = randomUUID();
       const now = new Date().toISOString();
 
@@ -138,6 +146,7 @@ export function registerDecisionCommands(parent: Command): void {
         confidence,
         decidedAt: now,
         ...(isLowConfidence ? { lowConfidence: true } : {}),
+        ...(katakaId ? { katakaId } : {}),
       };
 
       // Append to run-level decisions.jsonl

--- a/src/domain/types/run-state.ts
+++ b/src/domain/types/run-state.ts
@@ -230,6 +230,8 @@ export const DecisionEntrySchema = z.object({
    * decision log is fully self-describing.
    */
   lowConfidence: z.boolean().optional(),
+  /** ID of the kataka (agent) that recorded this decision. Auto-populated from run.json; overrideable with --kataka. */
+  katakaId: z.string().uuid().optional(),
 });
 
 export type DecisionEntry = z.infer<typeof DecisionEntrySchema>;
@@ -292,6 +294,8 @@ export const ArtifactIndexEntrySchema = z.object({
   type: ArtifactIndexTypeSchema,
   /** ISO 8601 timestamp when the artifact was recorded. */
   recordedAt: z.string().datetime(),
+  /** ID of the kataka (agent) that recorded this artifact. Auto-populated from run.json; overrideable with --kataka. */
+  katakaId: z.string().uuid().optional(),
 });
 
 export type ArtifactIndexEntry = z.infer<typeof ArtifactIndexEntrySchema>;


### PR DESCRIPTION
## Summary

- `kata kime record` and `kata maki record` now auto-attribute `katakaId` from `run.json` when `--kataka` is not provided, matching the existing behaviour of `kata kansatsu record`
- Added `katakaId: z.string().uuid().optional()` to `DecisionEntrySchema` and `ArtifactIndexEntrySchema` so `JsonlStore.append` preserves the field through Zod parse
- Added `--kataka <id>` CLI option to both commands as an explicit override

## Lookup chain

1. `--kataka <id>` flag — use explicitly
2. `run.json` `katakaId` field (from `readRun()` return value) — use if present
3. Neither — field omitted, no attribution

## Test plan

- [x] Auto-populates `katakaId` from `run.json` when `--kataka` not provided (artifact + decision)
- [x] Explicit `--kataka` flag overrides `run.json` value (artifact + decision)
- [x] `katakaId` left undefined when neither source is present (artifact + decision)
- [x] All 59 existing tests still pass

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)