### PR TITLE
feat: add --cwd to record commands in formatAgentContext (closes #231)

### DIFF
--- a/src/domain/types/observation.test.ts
+++ b/src/domain/types/observation.test.ts
@@ -59,9 +59,9 @@ describe('ObservationSchema — prediction', () => {
 });
 
 describe('ObservationSchema — friction', () => {
-  it('parses a friction with all 5 taxonomy values', () => {
+  it('parses a friction with all 6 taxonomy values', () => {
     const taxonomies = FrictionTaxonomy.options;
-    expect(taxonomies).toHaveLength(5);
+    expect(taxonomies).toHaveLength(6);
 
     for (const taxonomy of taxonomies) {
       const obs = ObservationSchema.parse({ ...BASE, type: 'friction', taxonomy });

--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -308,16 +308,17 @@ describe('SessionExecutionBridge', () => {
       expect(context).toContain(`- **Bet ID**: ${prepared.betId}`);
       expect(context).toContain(`- **Kata dir**: ${kataDir}`);
       expect(context).toContain('### Record as you work');
-      // kansatsu: positional type + content, --run flag (not --run-id)
-      expect(context).toContain(`kata kansatsu record <type> "..." --run ${prepared.runId}`);
+      // kansatsu: --cwd pre-filled + positional type + content + --run flag
+      expect(context).toContain(`kata --cwd `);
+      expect(context).toContain(`kansatsu record <type> "..." --run ${prepared.runId}`);
       // observation types and quality guide present
       expect(context).toContain('**Observation types**');
       expect(context).toContain('**Friction taxonomy**');
       expect(context).toContain('**Quality bar**');
-      // maki: positional name + path, --run flag
-      expect(context).toContain(`kata maki record <name> <path> --run ${prepared.runId}`);
-      // kime: named flags only, --run flag (not --run-id)
-      expect(context).toContain(`kata kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
+      // maki: --cwd pre-filled + positional name + path + --run flag
+      expect(context).toContain(`maki record <name> <path> --run ${prepared.runId}`);
+      // kime: --cwd pre-filled + named flags + --run flag
+      expect(context).toContain(`kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
       expect(context).toContain("### When you're done");
       expect(context).toContain('Do NOT close the run yourself');
     });

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { existsSync, readdirSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import type {
   ISessionExecutionBridge,
@@ -114,6 +114,8 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
 
   formatAgentContext(prepared: PreparedRun): string {
     const lines: string[] = [];
+    // --cwd takes the repo root (parent of .kata/), used in all kata CLI invocations
+    const repoRoot = dirname(prepared.kataDir);
 
     lines.push('## Kata Run Context');
     lines.push('');
@@ -181,9 +183,9 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
     lines.push('### Record as you work');
     lines.push('Use these commands at natural checkpoints — when a decision matters, when something surprises you, when you hit resistance:');
     lines.push('');
-    lines.push(`  kata kansatsu record <type> "..." --run ${prepared.runId}`);
-    lines.push(`  kata maki record <name> <path> --run ${prepared.runId}`);
-    lines.push(`  kata kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
+    lines.push(`  kata --cwd ${repoRoot} kansatsu record <type> "..." --run ${prepared.runId}`);
+    lines.push(`  kata --cwd ${repoRoot} maki record <name> <path> --run ${prepared.runId}`);
+    lines.push(`  kata --cwd ${repoRoot} kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
     lines.push('');
     lines.push('**Observation types** — pick the most specific:');
     lines.push('  decision    — a choice between real alternatives; always include WHY you chose this path');


### PR DESCRIPTION
## Summary

- `formatAgentContext()` now pre-fills `--cwd <repoRoot>` in all kansatsu, maki, and kime example commands
- `repoRoot` derived as `dirname(kataDir)` so commands work from any worktree without .kata auto-resolution failure (#258)
- Fixes pre-existing test count mismatch: observation.test.ts expected 5 FrictionTaxonomy values but agent-override added in #301 made it 6

## What was already there vs what was added

**Already present:** Run ID, Bet ID, Cycle ID, Kata dir, Stages, What to produce, Git workflow (branch + KATA_RUN_ID), record commands, observation types, friction taxonomy, quality bar, injected learnings, when-done instructions.

**Added:** --cwd pre-filled in record commands.

## Test plan
- [x] 3038 tests pass (147 files)
- [x] typecheck clean
- [x] lint 0 errors

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>