### PR TITLE
fix: keiko-9 batch — stale dist, ranWithYolo, bet.runId backfill, 0 observations

### DIFF
--- a/src/cli/commands/cycle.test.ts
+++ b/src/cli/commands/cycle.test.ts
@@ -1151,6 +1151,37 @@ describe('registerCycleCommands', () => {
       expect(updated.state).toBe('complete');
     }, 30000);
 
+    // Issue #329 — ranWithYolo must be set after --yolo cooldown completes.
+    // Belt progression checks project-state.json for ranWithYolo=true; if it
+    // is never written, go-kyu advancement is permanently blocked.
+    it('--yolo sets ranWithYolo=true in project-state.json after complete()', async () => {
+      const { loadProjectState } = await import('@features/belt/belt-calculator.js');
+
+      const manager = new CycleManager(cyclesDir, JsonStore);
+      const cycle = manager.create({ tokenBudget: 50000 }, 'Yolo RanWithYolo Test');
+
+      const synthesisDir = join(kataDir, 'synthesis');
+      mkdirSync(synthesisDir, { recursive: true });
+
+      const originalPath = process.env['PATH'];
+      process.env['PATH'] = '';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--cwd', baseDir,
+        'cooldown', cycle.id, '--yolo',
+      ]);
+
+      process.env['PATH'] = originalPath;
+      warnSpy.mockRestore();
+
+      // project-state.json must record ranWithYolo=true (#329 fix)
+      const stateFile = join(kataDir, 'project-state.json');
+      const state = loadProjectState(stateFile);
+      expect(state.ranWithYolo).toBe(true);
+    }, 30000);
+
     it('--auto-accept-suggestions includes suggestionReview in --json output', async () => {
       const { RuleRegistry } = await import('@infra/registries/rule-registry.js');
       const rulesDir = join(kataDir, 'rules');

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -1097,8 +1097,10 @@ export function registerCycleCommands(parent: Command): void {
           return;
         }
 
-        // Fire-and-forget belt discovery hook
-        ProjectStateUpdater.markDiscovery(join(ctx.kataDir, 'project-state.json'), 'completedFirstCycleCooldown');
+        // Fire-and-forget belt discovery hooks
+        const projectStateFile = join(ctx.kataDir, 'project-state.json');
+        ProjectStateUpdater.markDiscovery(projectStateFile, 'completedFirstCycleCooldown');
+        ProjectStateUpdater.markRanWithYolo(projectStateFile);
 
         if (ctx.globalOpts.json) {
           console.log(JSON.stringify({

--- a/src/cli/dist-freshness.ts
+++ b/src/cli/dist-freshness.ts
@@ -1,0 +1,87 @@
+/**
+ * Build-freshness guard.
+ *
+ * Compares the mtime of the newest `.ts` file under `src/` against the mtime
+ * of the CLI entry in `dist/cli/index.js`.  If dist is older than src, a
+ * yellow warning is printed to stderr so operators know they should rebuild
+ * before dispatching agents.
+ *
+ * This is intentionally non-blocking: the warning is advisory only.
+ * Uses only Node.js built-ins (fs, path, url) — no external dependencies.
+ */
+
+import { statSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Walk `dir` recursively and return the highest mtime (ms) found across all
+ * files matching `ext`.  Returns 0 if no matching files are found.
+ */
+function newestMtime(dir: string, ext: string): number {
+  let max = 0;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const child = newestMtime(full, ext);
+        if (child > max) max = child;
+      } else if (entry.isFile() && entry.name.endsWith(ext)) {
+        try {
+          const t = statSync(full).mtimeMs;
+          if (t > max) max = t;
+        } catch {
+          // Unreadable file — skip
+        }
+      }
+    }
+  } catch {
+    // Unreadable directory — skip
+  }
+  return max;
+}
+
+/**
+ * Check whether dist/ is stale relative to src/ and warn if so.
+ *
+ * The sentinel for dist/ is `dist/cli/index.js` — the actual binary entry.
+ * The project root is derived from `import.meta.url` at runtime so the check
+ * works regardless of which directory the CLI is invoked from.
+ *
+ * This function never throws; any unexpected error is silently swallowed so
+ * the guard cannot break the CLI.
+ */
+export function warnIfDistStale(): void {
+  try {
+    // dist/cli/index.js → dist/cli/ → dist/ → project root
+    const distCliEntry = fileURLToPath(import.meta.url);
+    // When compiled: dist/cli/dist-freshness.js
+    const distCliDir = dirname(distCliEntry);   // dist/cli/
+    const distDir = dirname(distCliDir);         // dist/
+    const projectRoot = dirname(distDir);        // project root
+
+    const srcDir = join(projectRoot, 'src');
+    const distSentinel = join(distCliDir, 'index.js');
+
+    // Newest .ts file mtime in src/
+    const srcMtime = newestMtime(srcDir, '.ts');
+    if (srcMtime === 0) return; // src/ not found — dev environment quirk, skip
+
+    // mtime of the dist sentinel
+    let distMtime: number;
+    try {
+      distMtime = statSync(distSentinel).mtimeMs;
+    } catch {
+      // dist/cli/index.js doesn't exist — running via tsx/ts-node, skip
+      return;
+    }
+
+    if (srcMtime > distMtime) {
+      process.stderr.write(
+        '\x1b[33m⚠ dist may be stale — run "npm run build" before dispatching agents\x1b[0m\n',
+      );
+    }
+  } catch {
+    // Never let the freshness check crash the CLI
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,8 @@
 import { createProgram } from './program.js';
 import { handleCommandError } from './utils.js';
+import { warnIfDistStale } from './dist-freshness.js';
+
+warnIfDistStale();
 
 const program = createProgram();
 

--- a/src/features/cycle-management/cooldown-session-prepare.test.ts
+++ b/src/features/cycle-management/cooldown-session-prepare.test.ts
@@ -1,10 +1,14 @@
 import { join } from 'node:path';
-import { mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 import { CycleManager } from '@domain/services/cycle-manager.js';
 import { KnowledgeStore } from '@infra/knowledge/knowledge-store.js';
 import { JsonStore } from '@infra/persistence/json-store.js';
 import { SynthesisInputSchema } from '@domain/types/synthesis.js';
+import { appendObservation, createRunTree } from '@infra/persistence/run-store.js';
+import type { Run } from '@domain/types/run-state.js';
+import type { Observation } from '@domain/types/observation.js';
 import {
   CooldownSession,
   type CooldownSessionDeps,
@@ -434,5 +438,188 @@ describe('CooldownSession.complete()', () => {
 
     expect(cycleManager.get(cycle.id).state).toBe('complete');
     expect(result.synthesisProposals).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observation wiring: synthesis input collects observations from runs (#335)
+// ---------------------------------------------------------------------------
+
+describe('CooldownSession.prepare() — observation wiring', () => {
+  const baseDir = join(tmpdir(), `kata-obs-wiring-test-${Date.now()}`);
+  const cyclesDir = join(baseDir, 'cycles');
+  const knowledgeDir = join(baseDir, 'knowledge');
+  const pipelineDir = join(baseDir, 'pipelines');
+  const historyDir = join(baseDir, 'history');
+  const synthesisDir = join(baseDir, 'synthesis');
+  const runsDir = join(baseDir, 'runs');
+  const bridgeRunsDir = join(baseDir, 'bridge-runs');
+
+  let cycleManager: CycleManager;
+  let knowledgeStore: KnowledgeStore;
+
+  function makeRun(cycleId: string, betId: string): Run {
+    return {
+      id: randomUUID(),
+      cycleId,
+      betId,
+      betPrompt: 'Test bet',
+      stageSequence: ['research', 'build'],
+      currentStage: null,
+      status: 'completed',
+      startedAt: new Date().toISOString(),
+    };
+  }
+
+  function makeObservation(content: string): Observation {
+    return {
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      type: 'insight',
+      content,
+    };
+  }
+
+  function writeBridgeRun(runId: string, betId: string, cycleId: string): void {
+    const meta = { runId, betId, cycleId, cycleName: cycleId, stages: ['research', 'build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'complete' };
+    writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify(meta, null, 2) + '\n');
+  }
+
+  function makeDeps(overrides: Partial<CooldownSessionDeps> = {}): CooldownSessionDeps {
+    return {
+      cycleManager,
+      knowledgeStore,
+      persistence: JsonStore,
+      pipelineDir,
+      historyDir,
+      synthesisDir,
+      runsDir,
+      bridgeRunsDir,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    for (const dir of [cyclesDir, knowledgeDir, pipelineDir, historyDir, synthesisDir, runsDir, bridgeRunsDir]) {
+      mkdirSync(dir, { recursive: true });
+    }
+    cycleManager = new CycleManager(cyclesDir, JsonStore);
+    knowledgeStore = new KnowledgeStore(knowledgeDir);
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('includes run-level observations in synthesis input when bet.runId is set', async () => {
+    const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Obs Test');
+    const withBet = cycleManager.addBet(cycle.id, { description: 'Bet A', appetite: 30, outcome: 'pending', issueRefs: [] });
+    const bet = withBet.bets[0]!;
+
+    const run = makeRun(cycle.id, bet.id);
+    createRunTree(runsDir, run);
+    cycleManager.setRunId(cycle.id, bet.id, run.id);
+
+    const obs = makeObservation('Insight from run');
+    appendObservation(runsDir, run.id, obs, { level: 'run' });
+
+    const session = new CooldownSession(makeDeps());
+    const result = await session.prepare(cycle.id);
+
+    const raw = readFileSync(result.synthesisInputPath, 'utf-8');
+    const input = SynthesisInputSchema.parse(JSON.parse(raw));
+    expect(input.observations).toHaveLength(1);
+    expect(input.observations[0]!.content).toBe('Insight from run');
+  });
+
+  it('finds observations via bridge-run lookup when bet.runId is missing (staged workflow fix — #335)', async () => {
+    // Simulate a staged-workflow cycle: bets have NO runId on the cycle record,
+    // but bridge-run files exist with the betId → runId mapping.
+    const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Staged Obs Test');
+    const withBet = cycleManager.addBet(cycle.id, { description: 'Staged bet', appetite: 40, outcome: 'pending', issueRefs: [] });
+    const bet = withBet.bets[0]!;
+
+    // bet.runId is NOT set on the cycle (simulates pre-backfill staged launch)
+    expect(cycleManager.get(cycle.id).bets[0]!.runId).toBeUndefined();
+
+    const run = makeRun(cycle.id, bet.id);
+    createRunTree(runsDir, run);
+    // Write bridge-run file with the betId → runId mapping
+    writeBridgeRun(run.id, bet.id, cycle.id);
+
+    const obs = makeObservation('Discovered via bridge-run lookup');
+    appendObservation(runsDir, run.id, obs, { level: 'run' });
+
+    const session = new CooldownSession(makeDeps());
+    const result = await session.prepare(cycle.id);
+
+    const raw = readFileSync(result.synthesisInputPath, 'utf-8');
+    const input = SynthesisInputSchema.parse(JSON.parse(raw));
+    expect(input.observations).toHaveLength(1);
+    expect(input.observations[0]!.content).toBe('Discovered via bridge-run lookup');
+  });
+
+  it('collects stage-level observations in addition to run-level (#335)', async () => {
+    const cycle = cycleManager.create({ tokenBudget: 50000 }, 'All Levels Test');
+    const withBet = cycleManager.addBet(cycle.id, { description: 'Multi-level bet', appetite: 30, outcome: 'pending', issueRefs: [] });
+    const bet = withBet.bets[0]!;
+
+    const run = makeRun(cycle.id, bet.id);
+    createRunTree(runsDir, run);
+    cycleManager.setRunId(cycle.id, bet.id, run.id);
+
+    // Write observations at run level and stage level
+    appendObservation(runsDir, run.id, makeObservation('Run-level insight'), { level: 'run' });
+    appendObservation(runsDir, run.id, makeObservation('Research-stage insight'), { level: 'stage', category: 'research' });
+
+    const session = new CooldownSession(makeDeps());
+    const result = await session.prepare(cycle.id);
+
+    const raw = readFileSync(result.synthesisInputPath, 'utf-8');
+    const input = SynthesisInputSchema.parse(JSON.parse(raw));
+    expect(input.observations.length).toBeGreaterThanOrEqual(2);
+    const contents = input.observations.map((o) => o.content);
+    expect(contents).toContain('Run-level insight');
+    expect(contents).toContain('Research-stage insight');
+  });
+
+  it('aggregates observations from all bets in the cycle', async () => {
+    const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Multi-Bet Test');
+    const withBetA = cycleManager.addBet(cycle.id, { description: 'Bet A', appetite: 25, outcome: 'pending', issueRefs: [] });
+    const withBetB = cycleManager.addBet(cycle.id, { description: 'Bet B', appetite: 25, outcome: 'pending', issueRefs: [] });
+    const betA = withBetA.bets[0]!;
+    const betB = withBetB.bets[1]!;
+
+    const runA = makeRun(cycle.id, betA.id);
+    const runB = makeRun(cycle.id, betB.id);
+    createRunTree(runsDir, runA);
+    createRunTree(runsDir, runB);
+    cycleManager.setRunId(cycle.id, betA.id, runA.id);
+    cycleManager.setRunId(cycle.id, betB.id, runB.id);
+
+    appendObservation(runsDir, runA.id, makeObservation('From bet A'), { level: 'run' });
+    appendObservation(runsDir, runB.id, makeObservation('From bet B'), { level: 'run' });
+
+    const session = new CooldownSession(makeDeps());
+    const result = await session.prepare(cycle.id);
+
+    const raw = readFileSync(result.synthesisInputPath, 'utf-8');
+    const input = SynthesisInputSchema.parse(JSON.parse(raw));
+    expect(input.observations.length).toBeGreaterThanOrEqual(2);
+    const contents = input.observations.map((o) => o.content);
+    expect(contents).toContain('From bet A');
+    expect(contents).toContain('From bet B');
+  });
+
+  it('returns 0 observations when no runs or bridge-runs exist', async () => {
+    const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Empty Obs Test');
+    cycleManager.addBet(cycle.id, { description: 'No run bet', appetite: 30, outcome: 'pending', issueRefs: [] });
+
+    const session = new CooldownSession(makeDeps());
+    const result = await session.prepare(cycle.id);
+
+    const raw = readFileSync(result.synthesisInputPath, 'utf-8');
+    const input = SynthesisInputSchema.parse(JSON.parse(raw));
+    expect(input.observations).toHaveLength(0);
   });
 });

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import type { CycleManager, CooldownReport } from '@domain/services/cycle-manager.js';
 import type { IKnowledgeStore } from '@domain/ports/knowledge-store.js';
 import type { IPersistence } from '@domain/ports/persistence.js';
@@ -20,7 +20,7 @@ import { CalibrationDetector } from '@features/self-improvement/calibration-dete
 import { HierarchicalPromoter } from '@infra/knowledge/hierarchical-promoter.js';
 import { FrictionAnalyzer } from '@features/self-improvement/friction-analyzer.js';
 import { JsonStore } from '@infra/persistence/json-store.js';
-import { readObservations, readRun } from '@infra/persistence/run-store.js';
+import { readAllObservationsForRun, readRun } from '@infra/persistence/run-store.js';
 import type { Observation } from '@domain/types/observation.js';
 import {
   SynthesisInputSchema,
@@ -697,10 +697,16 @@ export class CooldownSession {
   }
 
   /**
-   * Read all run-level observations for every bet in the cycle, then write
-   * a SynthesisInput file to .kata/synthesis/pending-<id>.json.
+   * Read all observations for every bet in the cycle (across all levels: run,
+   * stage, flavor, step), then write a SynthesisInput file to
+   * .kata/synthesis/pending-<id>.json.
    * Returns the synthesisInputId and synthesisInputPath.
    * Non-critical: if synthesisDir is not configured, returns placeholder values.
+   *
+   * Run ID resolution order for each bet:
+   *   1. bet.runId (set by CycleManager.setRunId / backfillRunIdInCycle on prepare)
+   *   2. Bridge-run lookup by cycleId+betId (fallback for staged-workflow cycles
+   *      launched before backfillRunIdInCycle was wired — fixes #337 / #335)
    */
   private writeSynthesisInput(
     cycleId: string,
@@ -718,15 +724,31 @@ export class CooldownSession {
     const id = crypto.randomUUID();
     const observations: Observation[] = [];
 
-    // Collect run-level observations for each bet that has a runId
+    // Build a betId → runId map from bridge-run files (fallback for missing bet.runId).
+    // Only loaded when bridgeRunsDir is configured — lazy, O(n bridge-runs) at most once.
+    const bridgeRunIdByBetId = this.deps.bridgeRunsDir
+      ? this.loadBridgeRunIdsByBetId(cycleId, this.deps.bridgeRunsDir)
+      : new Map<string, string>();
+
+    // Collect all observations across every level for each bet
     if (this.deps.runsDir) {
       for (const bet of cycle.bets) {
-        if (!bet.runId) continue;
+        // Prefer bet.runId (forward link set by prepare); fall back to bridge-run lookup
+        const runId = bet.runId ?? bridgeRunIdByBetId.get(bet.id);
+        if (!runId) continue;
         try {
-          const runObs = readObservations(this.deps.runsDir, bet.runId, { level: 'run' });
+          // Read run.json to get stageSequence for full-tree observation scan
+          let stageSequence: import('@domain/types/stage.js').StageCategory[] = [];
+          try {
+            const run = readRun(this.deps.runsDir, runId);
+            stageSequence = run.stageSequence;
+          } catch {
+            // run.json not found — fall back to run-level only
+          }
+          const runObs = readAllObservationsForRun(this.deps.runsDir, runId, stageSequence);
           observations.push(...runObs);
         } catch (err) {
-          logger.warn(`Failed to read observations for run ${bet.runId}: ${err instanceof Error ? err.message : String(err)}`);
+          logger.warn(`Failed to read observations for run ${runId} (bet ${bet.id}): ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     }
@@ -755,6 +777,41 @@ export class CooldownSession {
     JsonStore.write(filePath, synthesisInput, SynthesisInputSchema);
 
     return { synthesisInputId: id, synthesisInputPath: filePath };
+  }
+
+  /**
+   * Build a betId → runId map by scanning bridge-run files for the given cycle.
+   *
+   * This is the fallback lookup used by writeSynthesisInput() when bet.runId is
+   * not set on the cycle record (e.g., staged-workflow cycles launched before
+   * backfillRunIdInCycle was introduced in SessionExecutionBridge — fixes #335).
+   *
+   * Returns an empty Map when bridgeRunsDir is missing or unreadable.
+   */
+  private loadBridgeRunIdsByBetId(cycleId: string, bridgeRunsDir: string): Map<string, string> {
+    const result = new Map<string, string>();
+    if (!existsSync(bridgeRunsDir)) return result;
+
+    let files: string[];
+    try {
+      files = readdirSync(bridgeRunsDir).filter((f) => f.endsWith('.json'));
+    } catch {
+      return result;
+    }
+
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(bridgeRunsDir, file), 'utf-8');
+        const meta = JSON.parse(raw) as { cycleId?: string; betId?: string; runId?: string };
+        if (meta.cycleId === cycleId && meta.betId && meta.runId) {
+          result.set(meta.betId, meta.runId);
+        }
+      } catch {
+        // Skip unreadable / invalid bridge-run files
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -102,6 +102,51 @@ describe('SessionExecutionBridge', () => {
       expect(meta.cycleId).toBe(cycle.id);
     });
 
+    it('should backfill bet.runId in cycle JSON after prepare() (#337)', () => {
+      const cycle = createCycle(kataDir);
+      const betId = cycle.bets[0]!.id;
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepare(betId);
+
+      // The cycle JSON should now have the runId on the bet
+      const cyclePath = join(kataDir, 'cycles', `${cycle.id}.json`);
+      const updatedCycle = CycleSchema.parse(JSON.parse(readFileSync(cyclePath, 'utf-8')));
+      const updatedBet = updatedCycle.bets.find((b) => b.id === betId);
+      expect(updatedBet?.runId).toBe(prepared.runId);
+    });
+
+    it('should not affect other bets when backfilling runId (#337)', () => {
+      const cycle = createCycle(kataDir);
+      const betId = cycle.bets[0]!.id;
+      const otherBetId = cycle.bets[1]!.id;
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      bridge.prepare(betId);
+
+      const cyclePath = join(kataDir, 'cycles', `${cycle.id}.json`);
+      const updatedCycle = CycleSchema.parse(JSON.parse(readFileSync(cyclePath, 'utf-8')));
+      const otherBet = updatedCycle.bets.find((b) => b.id === otherBetId);
+      // The other bet should still have no runId
+      expect(otherBet?.runId).toBeUndefined();
+    });
+
+    it('prepareCycle() should backfill runId on all bet records (#337)', () => {
+      const cycle = createCycle(kataDir, { state: 'planning' });
+      const bridge = new SessionExecutionBridge(kataDir);
+
+      const prepared = bridge.prepareCycle(cycle.id);
+
+      const cyclePath = join(kataDir, 'cycles', `${cycle.id}.json`);
+      const updatedCycle = CycleSchema.parse(JSON.parse(readFileSync(cyclePath, 'utf-8')));
+
+      expect(prepared.preparedRuns).toHaveLength(2);
+      for (const run of prepared.preparedRuns) {
+        const updatedBet = updatedCycle.bets.find((b) => b.id === run.betId);
+        expect(updatedBet?.runId).toBe(run.runId);
+      }
+    });
+
     it('should throw for unknown bet ID', () => {
       createCycle(kataDir);
       const bridge = new SessionExecutionBridge(kataDir);

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -113,6 +113,12 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
       katakaId,
     });
 
+    // Backfill the runId onto the bet record in the cycle JSON so that queries
+    // and reports that look up "the run for a bet" can do O(1) forward lookup.
+    // Non-critical: errors are logged as warnings — a failed backfill should
+    // not abort prepare() since the bridge-run metadata was already persisted.
+    this.backfillRunIdInCycle(cycle.id, bet.id, runId);
+
     // Write run.json to runs/<run-id>/run.json so kata watch can discover
     // this run. BridgeRunMeta uses status "in-progress" but RunSchema requires
     // "running" — we map on write. Only valid StageCategory values are written
@@ -700,6 +706,41 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
       JsonStore.write(cyclePath, cycle, CycleSchema);
     } catch (err) {
       logger.warn(`Failed to update bet outcome in cycle "${cycleId}" for bet "${betId}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Backfill the runId onto the bet record in the cycle JSON file.
+   *
+   * Called by prepare() after the bridge-run metadata and run.json are written.
+   * This is the staged-workflow equivalent of CycleManager.setRunId() used by
+   * `kata cycle start` — it enables O(1) forward lookup of "the run for a bet".
+   *
+   * Idempotent: overwrites any previously stored runId without error (safe on retry).
+   * Non-critical: errors are logged as warnings — the bridge-run metadata was already
+   * persisted and the agent can still execute.
+   */
+  private backfillRunIdInCycle(cycleId: string, betId: string, runId: string): void {
+    try {
+      const cyclesDir = join(this.kataDir, KATA_DIRS.cycles);
+      const cyclePath = join(cyclesDir, `${cycleId}.json`);
+      if (!existsSync(cyclePath)) {
+        logger.warn(`Cannot backfill bet.runId: cycle file not found for cycle "${cycleId}".`);
+        return;
+      }
+
+      const cycle = JsonStore.read(cyclePath, CycleSchema);
+      const bet = cycle.bets.find((b) => b.id === betId);
+      if (!bet) {
+        logger.warn(`Cannot backfill bet.runId: bet "${betId}" not found in cycle "${cycleId}".`);
+        return;
+      }
+
+      bet.runId = runId;
+      cycle.updatedAt = new Date().toISOString();
+      JsonStore.write(cyclePath, cycle, CycleSchema);
+    } catch (err) {
+      logger.warn(`Failed to backfill bet.runId in cycle "${cycleId}" for bet "${betId}": ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 


### PR DESCRIPTION
## Keiko 9 — Runs #326 #329 #337 #335

Four bets implemented together (branch contention from parallel agent dispatch collapsed them):

### #326 — Stale dist guard
`src/cli/dist-freshness.ts` + wired into `src/cli/index.ts`. Compares mtime of newest `.ts` in `src/` vs `dist/cli/index.js`. Non-blocking — yellow stderr warning only.

### #329 — ranWithYolo not set in --yolo path
`src/cli/commands/cycle.ts`: added `ProjectStateUpdater.markRanWithYolo(projectStateFile)` call in the `--yolo` cooldown complete handler. Belt progression was permanently blocked without this.

### #337 — bet.runId backfill from bridge-runs
`src/infrastructure/execution/session-bridge.ts`: `backfillRunIdInCycle()` called after `prepare()` writes bridge-run metadata. Enables O(1) forward lookup of "the run for a bet".

### #335 — 0 observations in synthesis
`src/features/cycle-management/cooldown-session.ts`:
- Switched from `readObservations` (run-level only) to `readAllObservationsForRun` (all levels)
- Added `loadBridgeRunIdsByBetId()` fallback: when `bet.runId` is missing, scans bridge-run files by cycleId+betId to resolve the runId
- Fixes synthesis always showing 0 observations for staged-workflow cycles

## Test plan
- [x] `session-bridge.test.ts` — 55 tests pass (includes 3 new backfill tests)
- [x] `cooldown-session-prepare.test.ts` — 24 tests pass (includes new observation wiring suite)
- [x] `cycle.test.ts -t "ranWithYolo"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build freshness check: CLI now warns on startup if source code is newer than compiled output.
  * Enhanced observation gathering to include multi-level scanning from runs and stages.

* **Bug Fixes**
  * Improved run ID resolution by using bridge-run metadata as fallback when direct run ID is unavailable.
  * Enhanced error messages when reading cycle observations.

* **Tests**
  * Added tests for --yolo flag tracking in cycle cooldown.
  * Added tests for observation wiring and run ID backfilling in cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->