### PR TITLE
fix: bridge-run fallback in collectObservations for next-keiko proposals

### DIFF
--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -1246,6 +1246,7 @@ export class CooldownSession {
       return this._nextKeikoProposalGenerator.generate({
         cycle,
         runsDir: this.deps.runsDir,
+        bridgeRunsDir: this.deps.bridgeRunsDir,
         milestoneName: this.deps.nextKeikoMilestoneName,
         completedBets,
       });

--- a/src/features/cycle-management/next-keiko-proposal-generator.test.ts
+++ b/src/features/cycle-management/next-keiko-proposal-generator.test.ts
@@ -386,3 +386,206 @@ describe('NextKeikoProposalGenerator', () => {
     expect(result.text).toContain('2 open milestone issues');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bridge-run fallback — collectObservations resolves runId via bridge-run file
+// ---------------------------------------------------------------------------
+
+describe('NextKeikoProposalGenerator — bridge-run fallback (#348)', () => {
+  const baseDir = join(tmpdir(), `next-keiko-bridge-test-${Date.now()}`);
+  const runsDir = join(baseDir, 'runs');
+  const bridgeRunsDir = join(baseDir, 'bridge-runs');
+
+  beforeEach(() => {
+    mkdirSync(runsDir, { recursive: true });
+    mkdirSync(bridgeRunsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('collects observations for bets with null runId via bridge-run lookup', () => {
+    const cycleId = randomUUID();
+    const betId = randomUUID();
+    const runId = randomUUID();
+
+    // Create run directory with observations
+    const runDir = join(runsDir, runId);
+    mkdirSync(runDir, { recursive: true });
+    writeObsFile(runDir, [
+      makeObs('friction', 'Bridge fallback friction'),
+      makeObs('gap', 'Bridge fallback gap'),
+    ]);
+
+    // Write bridge-run file (bet.runId is null — only the bridge-run file has the mapping)
+    writeFileSync(
+      join(bridgeRunsDir, `${runId}.json`),
+      JSON.stringify({ cycleId, betId, runId, status: 'complete' }),
+      'utf-8',
+    );
+
+    // Bet has NO runId — this is the bug scenario
+    const cycle = {
+      id: cycleId,
+      name: 'Test Cycle',
+      state: 'complete' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      bets: [
+        {
+          id: betId,
+          description: 'Bet without runId',
+          appetite: 20,
+          outcome: 'complete' as const,
+          issueRefs: [],
+          runId: undefined, // null — triggers the bug without the fix
+        },
+      ],
+      pipelineMappings: [],
+      budget: {},
+    } as unknown as Cycle;
+
+    const mockClaude = vi.fn().mockReturnValue(
+      '=== Next Keiko Proposals ===\n\nRecommended bets (ranked):\n  1. Fixed bet    appetite: S    signal: Bridge fallback worked\n',
+    );
+
+    const gen = new NextKeikoProposalGenerator({ invokeClaude: mockClaude });
+
+    // Without bridgeRunsDir — should find 0 observations (old broken behaviour)
+    const resultWithout = gen.generate({ cycle, runsDir, completedBets: [] });
+    expect(resultWithout.observationCounts.total).toBe(0);
+
+    // With bridgeRunsDir — should resolve via bridge-run file and find 2 observations
+    const resultWith = gen.generate({ cycle, runsDir, bridgeRunsDir, completedBets: [] });
+    expect(resultWith.observationCounts.total).toBe(2);
+    expect(resultWith.observationCounts.friction).toBe(1);
+    expect(resultWith.observationCounts.gap).toBe(1);
+  });
+
+  it('ignores bridge-run files for other cycles', () => {
+    const cycleId = randomUUID();
+    const otherCycleId = randomUUID();
+    const betId = randomUUID();
+    const runId = randomUUID();
+
+    const runDir = join(runsDir, runId);
+    mkdirSync(runDir, { recursive: true });
+    writeObsFile(runDir, [makeObs('friction', 'Should not appear')]);
+
+    // Bridge-run belongs to a different cycle
+    writeFileSync(
+      join(bridgeRunsDir, `${runId}.json`),
+      JSON.stringify({ cycleId: otherCycleId, betId, runId, status: 'complete' }),
+      'utf-8',
+    );
+
+    const cycle = {
+      id: cycleId,
+      name: 'Test Cycle',
+      state: 'complete' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      bets: [
+        {
+          id: betId,
+          description: 'Bet without runId',
+          appetite: 20,
+          outcome: 'complete' as const,
+          issueRefs: [],
+          runId: undefined,
+        },
+      ],
+      pipelineMappings: [],
+      budget: {},
+    } as unknown as Cycle;
+
+    const mockClaude = vi.fn().mockReturnValue('=== Next Keiko Proposals ===\n\nRecommended bets (ranked):\n  1. x    appetite: S    signal: y\n');
+    const gen = new NextKeikoProposalGenerator({ invokeClaude: mockClaude });
+
+    const result = gen.generate({ cycle, runsDir, bridgeRunsDir, completedBets: [] });
+    expect(result.observationCounts.total).toBe(0);
+  });
+
+  it('handles missing bridgeRunsDir gracefully', () => {
+    const cycle = {
+      id: randomUUID(),
+      name: 'Test Cycle',
+      state: 'complete' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      bets: [
+        {
+          id: randomUUID(),
+          description: 'Bet without runId',
+          appetite: 20,
+          outcome: 'complete' as const,
+          issueRefs: [],
+          runId: undefined,
+        },
+      ],
+      pipelineMappings: [],
+      budget: {},
+    } as unknown as Cycle;
+
+    const mockClaude = vi.fn().mockReturnValue('=== Next Keiko Proposals ===\n\nRecommended bets (ranked):\n  1. x    appetite: S    signal: y\n');
+    const gen = new NextKeikoProposalGenerator({ invokeClaude: mockClaude });
+
+    // bridgeRunsDir points to non-existent path — should not throw
+    expect(() =>
+      gen.generate({ cycle, runsDir, bridgeRunsDir: join(baseDir, 'no-such-dir'), completedBets: [] }),
+    ).not.toThrow();
+  });
+
+  it('prefers bet.runId over bridge-run lookup when both are present', () => {
+    const cycleId = randomUUID();
+    const betId = randomUUID();
+    const directRunId = randomUUID(); // The one bet.runId points to
+    const bridgeRunId = randomUUID(); // The one the bridge-run file points to
+
+    // Create both run directories with different observations
+    const directRunDir = join(runsDir, directRunId);
+    mkdirSync(directRunDir, { recursive: true });
+    writeObsFile(directRunDir, [makeObs('friction', 'From direct runId')]);
+
+    const bridgeRunDir = join(runsDir, bridgeRunId);
+    mkdirSync(bridgeRunDir, { recursive: true });
+    writeObsFile(bridgeRunDir, [makeObs('gap', 'From bridge-run fallback')]);
+
+    // Bridge-run file maps betId → bridgeRunId
+    writeFileSync(
+      join(bridgeRunsDir, `${bridgeRunId}.json`),
+      JSON.stringify({ cycleId, betId, runId: bridgeRunId, status: 'complete' }),
+      'utf-8',
+    );
+
+    const cycle = {
+      id: cycleId,
+      name: 'Test Cycle',
+      state: 'complete' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      bets: [
+        {
+          id: betId,
+          description: 'Bet with explicit runId',
+          appetite: 20,
+          outcome: 'complete' as const,
+          issueRefs: [],
+          runId: directRunId, // bet.runId is set — should take priority
+        },
+      ],
+      pipelineMappings: [],
+      budget: {},
+    } as unknown as Cycle;
+
+    const mockClaude = vi.fn().mockReturnValue('=== Next Keiko Proposals ===\n\nRecommended bets (ranked):\n  1. x    appetite: S    signal: y\n');
+    const gen = new NextKeikoProposalGenerator({ invokeClaude: mockClaude });
+
+    const result = gen.generate({ cycle, runsDir, bridgeRunsDir, completedBets: [] });
+    // Should read from directRunId only (friction) — NOT from bridgeRunId (gap)
+    expect(result.observationCounts.friction).toBe(1);
+    expect(result.observationCounts.gap).toBe(0);
+    expect(result.observationCounts.total).toBe(1);
+  });
+});

--- a/src/features/cycle-management/next-keiko-proposal-generator.ts
+++ b/src/features/cycle-management/next-keiko-proposal-generator.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readdirSync, existsSync } from 'node:fs';
+import { readdirSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Cycle } from '@domain/types/cycle.js';
 import type { Observation } from '@domain/types/observation.js';
@@ -20,6 +20,12 @@ export interface MilestoneIssue {
 export interface NextKeikoInput {
   cycle: Cycle;
   runsDir: string;
+  /**
+   * Path to `.kata/bridge-runs/` directory.
+   * When provided, bets whose `bet.runId` is null/undefined will be resolved
+   * via bridge-run file lookup (same fallback as writeSynthesisInput — fixes #348).
+   */
+  bridgeRunsDir?: string;
   /** Milestone name to query for open issues. When omitted, issue list is skipped. */
   milestoneName?: string;
   /** Completed bet descriptions (for context). */
@@ -94,7 +100,7 @@ export class NextKeikoProposalGenerator {
    */
   generate(input: NextKeikoInput): NextKeikoResult {
     // 1. Collect observations from all cycle runs
-    const observations = this.collectObservations(input.cycle, input.runsDir);
+    const observations = this.collectObservations(input.cycle, input.runsDir, input.bridgeRunsDir);
 
     const frictionObs = observations.filter((o) => o.type === 'friction');
     const gapObs = observations.filter((o) => o.type === 'gap');
@@ -159,16 +165,27 @@ export class NextKeikoProposalGenerator {
    * Collect all observations from `.kata/runs/<run-id>/observations.jsonl`
    * for every bet in the cycle that has a runId.
    *
+   * When `bet.runId` is null/undefined, falls back to a bridge-run file lookup
+   * (same pattern as writeSynthesisInput — fixes #348).
+   *
    * Falls back to scanning all level-specific observation files when
    * run-level observations.jsonl is absent (forward compatible).
    */
-  private collectObservations(cycle: Cycle, runsDir: string): Observation[] {
+  private collectObservations(cycle: Cycle, runsDir: string, bridgeRunsDir?: string): Observation[] {
     const all: Observation[] = [];
 
-    for (const bet of cycle.bets) {
-      if (!bet.runId) continue;
+    // Build betId → runId fallback map from bridge-run files when bet.runId is missing.
+    // Only loaded when bridgeRunsDir is provided — lazy, scanned at most once.
+    const bridgeRunIdByBetId: Map<string, string> = bridgeRunsDir
+      ? loadBridgeRunIdsByBetId(cycle.id, bridgeRunsDir)
+      : new Map();
 
-      const runDir = join(runsDir, bet.runId);
+    for (const bet of cycle.bets) {
+      // Prefer bet.runId (forward link set by prepare); fall back to bridge-run lookup
+      const runId = bet.runId ?? bridgeRunIdByBetId.get(bet.id);
+      if (!runId) continue;
+
+      const runDir = join(runsDir, runId);
       if (!existsSync(runDir)) continue;
 
       // Run-level observations (primary source)
@@ -200,6 +217,46 @@ export class NextKeikoProposalGenerator {
 
     return all;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Bridge-run fallback helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a betId → runId map by scanning bridge-run files for the given cycle.
+ *
+ * This is the fallback used by collectObservations() when bet.runId is not set
+ * on the cycle record (e.g., staged-workflow cycles launched before
+ * backfillRunIdInCycle was wired — mirrors the fix in writeSynthesisInput,
+ * fixes #348).
+ *
+ * Returns an empty Map when bridgeRunsDir is missing or unreadable.
+ */
+function loadBridgeRunIdsByBetId(cycleId: string, bridgeRunsDir: string): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!existsSync(bridgeRunsDir)) return result;
+
+  let files: string[];
+  try {
+    files = readdirSync(bridgeRunsDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return result;
+  }
+
+  for (const file of files) {
+    try {
+      const raw = readFileSync(join(bridgeRunsDir, file), 'utf-8');
+      const meta = JSON.parse(raw) as { cycleId?: string; betId?: string; runId?: string };
+      if (meta.cycleId === cycleId && meta.betId && meta.runId) {
+        result.set(meta.betId, meta.runId);
+      }
+    } catch {
+      // Skip unreadable / invalid bridge-run files
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `NextKeikoProposalGenerator.collectObservations` was skipping bets with `null` `bet.runId`, producing zero observations and empty proposals every cycle for staged-workflow runs
- Applies the same bridge-run file lookup fallback introduced in Keiko 9 for `writeSynthesisInput` (#335): when `bet.runId` is absent, resolve runId by scanning bridge-run files (`cycleId + betId -> runId`)
- Adds `bridgeRunsDir?: string` to `NextKeikoInput` and threads it through from `CooldownSession.runNextKeikoProposals` (which already has `this.deps.bridgeRunsDir`)

## Changes

- `next-keiko-proposal-generator.ts`: add `bridgeRunsDir` to `NextKeikoInput`, extract `loadBridgeRunIdsByBetId` module-level helper, update `collectObservations` to use the fallback map
- `cooldown-session.ts`: pass `bridgeRunsDir: this.deps.bridgeRunsDir` in the `generate()` call inside `runNextKeikoProposals`
- `next-keiko-proposal-generator.test.ts`: 4 new tests covering fallback resolves observations, cross-cycle isolation, missing-dir safety, and `bet.runId` priority over bridge-run lookup

## Test plan

- [x] All 18 tests in `next-keiko-proposal-generator.test.ts` pass (14 existing + 4 new)
- [x] All 57 tests in `cooldown-session.test.ts` pass (no regressions)
- [x] Full suite: 3170 tests pass; 8 pre-existing timeout failures in `cli/commands/cycle.test.ts` are unrelated to this change

Closes #348
