### PR TITLE
fix: belt calculator reads 0 learnings (#340)

### DIFF
--- a/src/features/belt/belt-calculator.test.ts
+++ b/src/features/belt/belt-calculator.test.ts
@@ -60,7 +60,10 @@ function writeLearning(knowledgeDir: string, overrides: Record<string, unknown> 
     updatedAt: now,
     ...overrides,
   };
-  JsonStore.write(join(knowledgeDir, `${id}.json`), learning, LearningSchema);
+  // KnowledgeStore writes to knowledgeDir/learnings/ — mirror that structure here.
+  const learningsDir = join(knowledgeDir, 'learnings');
+  mkdirSync(learningsDir, { recursive: true });
+  JsonStore.write(join(learningsDir, `${id}.json`), learning, LearningSchema);
   return id;
 }
 

--- a/src/features/belt/belt-calculator.ts
+++ b/src/features/belt/belt-calculator.ts
@@ -169,8 +169,11 @@ export class BeltCalculator {
   }
 
   private readLearnings(): import('@domain/types/learning.js').Learning[] {
-    if (!existsSync(this.deps.knowledgeDir)) return [];
-    return JsonStore.list(this.deps.knowledgeDir, LearningSchema);
+    // KnowledgeStore writes learnings to knowledgeDir/learnings/ (not knowledgeDir directly).
+    // We must scan the learnings subdirectory to match where files are actually stored.
+    const learningsDir = join(this.deps.knowledgeDir, 'learnings');
+    if (!existsSync(learningsDir)) return [];
+    return JsonStore.list(learningsDir, LearningSchema);
   }
 
   private readRunMetrics(): {


### PR DESCRIPTION
BeltCalculator.readLearnings scanned knowledgeDir root but KnowledgeStore writes into a learnings subfolder. Fix: scan the subfolder. Closes #340.