### PR TITLE
fix(belt): wire dojo session write into cooldown complete path (#343)

### DIFF
--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -26,6 +26,8 @@ import type { Run } from '@domain/types/run-state.js';
 import { BeltCalculator, ProjectStateUpdater } from '@features/belt/belt-calculator.js';
 import { KatakaConfidenceCalculator } from '@features/kataka/kataka-confidence-calculator.js';
 import { KATA_DIRS } from '@shared/constants/paths.js';
+import { SessionBuilder } from '@features/dojo/session-builder.js';
+import { SessionStore } from '@infra/dojo/session-store.js';
 import {
   checkBetsForIssueRefs,
   formatStalenessWarnings,
@@ -854,6 +856,10 @@ export function registerCycleCommands(parent: Command): void {
 
       const runsDir = kataDirPath(ctx.kataDir, 'runs');
       const katakaDir = join(ctx.kataDir, KATA_DIRS.kataka);
+      const dojoDir = kataDirPath(ctx.kataDir, 'dojo');
+      const dojoSessionBuilder = new SessionBuilder({
+        sessionStore: new SessionStore(join(dojoDir, 'sessions')),
+      });
       const completeSession = new CooldownSession({
         cycleManager: manager,
         knowledgeStore,
@@ -862,8 +868,9 @@ export function registerCycleCommands(parent: Command): void {
         historyDir: kataDirPath(ctx.kataDir, 'history'),
         runsDir,
         ruleRegistry,
-        dojoDir: kataDirPath(ctx.kataDir, 'dojo'),
+        dojoDir,
         synthesisDir,
+        dojoSessionBuilder,
         beltCalculator: new BeltCalculator({
           cyclesDir: kataDirPath(ctx.kataDir, 'cycles'),
           knowledgeDir: kataDirPath(ctx.kataDir, 'knowledge'),
@@ -871,7 +878,7 @@ export function registerCycleCommands(parent: Command): void {
           flavorsDir: kataDirPath(ctx.kataDir, 'flavors'),
           savedKataDir: kataDirPath(ctx.kataDir, 'katas'),
           synthesisDir,
-          dojoSessionsDir: join(kataDirPath(ctx.kataDir, 'dojo'), 'sessions'),
+          dojoSessionsDir: join(dojoDir, 'sessions'),
         }),
         projectStateFile: join(ctx.kataDir, 'project-state.json'),
         katakaConfidenceCalculator: new KatakaConfidenceCalculator({
@@ -932,6 +939,10 @@ export function registerCycleCommands(parent: Command): void {
       const runsDir = kataDirPath(ctx.kataDir, 'runs');
       const katakaDir = join(ctx.kataDir, KATA_DIRS.kataka);
       const bridgeRunsDir = join(ctx.kataDir, KATA_DIRS.bridgeRuns);
+      const dojoDir = kataDirPath(ctx.kataDir, 'dojo');
+      const dojoSessionBuilder = new SessionBuilder({
+        sessionStore: new SessionStore(join(dojoDir, 'sessions')),
+      });
       const session = new CooldownSession({
         cycleManager: manager,
         knowledgeStore,
@@ -941,8 +952,9 @@ export function registerCycleCommands(parent: Command): void {
         runsDir,
         bridgeRunsDir,
         ruleRegistry,
-        dojoDir: kataDirPath(ctx.kataDir, 'dojo'),
+        dojoDir,
         synthesisDir,
+        dojoSessionBuilder,
         beltCalculator: new BeltCalculator({
           cyclesDir,
           knowledgeDir: kataDirPath(ctx.kataDir, 'knowledge'),
@@ -950,7 +962,7 @@ export function registerCycleCommands(parent: Command): void {
           flavorsDir: kataDirPath(ctx.kataDir, 'flavors'),
           savedKataDir: kataDirPath(ctx.kataDir, 'katas'),
           synthesisDir,
-          dojoSessionsDir: join(kataDirPath(ctx.kataDir, 'dojo'), 'sessions'),
+          dojoSessionsDir: join(dojoDir, 'sessions'),
         }),
         projectStateFile: join(ctx.kataDir, 'project-state.json'),
         katakaConfidenceCalculator: new KatakaConfidenceCalculator({

--- a/src/features/belt/belt-calculator.test.ts
+++ b/src/features/belt/belt-calculator.test.ts
@@ -185,12 +185,20 @@ describe('BeltCalculator', () => {
       expect(snap.flavorsTotal).toBe(2);
     });
 
-    it('counts dojo sessions', () => {
+    it('counts dojo sessions by subdirectory (each session is a dir with meta.json)', () => {
       const dojoSessionsDir = join(base, 'dojo', 'sessions');
-      mkdirSync(dojoSessionsDir, { recursive: true });
-      writeFileSync(join(dojoSessionsDir, 's1.json'), '{}');
-      writeFileSync(join(dojoSessionsDir, 's2.json'), '{}');
-      writeFileSync(join(dojoSessionsDir, 's3.json'), '{}');
+      // SessionStore creates <sessionsDir>/<uuid>/meta.json for each session
+      const id1 = randomUUID();
+      const id2 = randomUUID();
+      const id3 = randomUUID();
+      mkdirSync(join(dojoSessionsDir, id1), { recursive: true });
+      writeFileSync(join(dojoSessionsDir, id1, 'meta.json'), '{}');
+      mkdirSync(join(dojoSessionsDir, id2), { recursive: true });
+      writeFileSync(join(dojoSessionsDir, id2, 'meta.json'), '{}');
+      mkdirSync(join(dojoSessionsDir, id3), { recursive: true });
+      writeFileSync(join(dojoSessionsDir, id3, 'meta.json'), '{}');
+      // index.json at root should NOT be counted as a session
+      writeFileSync(join(dojoSessionsDir, 'index.json'), '{}');
 
       const calc = new BeltCalculator({ cyclesDir, knowledgeDir, dojoSessionsDir });
       const snap = calc.computeSnapshot();

--- a/src/features/belt/belt-calculator.ts
+++ b/src/features/belt/belt-calculator.ts
@@ -55,7 +55,7 @@ export class BeltCalculator {
     const flavorsTotal = this.countJsonFiles(this.deps.flavorsDir);
     const decisionOutcomePairs = this.countDecisionOutcomes();
     const katasSaved = this.countJsonFiles(this.deps.savedKataDir);
-    const dojoSessionsGenerated = this.countJsonFiles(this.deps.dojoSessionsDir);
+    const dojoSessionsGenerated = this.countDojoSessions(this.deps.dojoSessionsDir);
     const { synthesisApplied, methodologyRecommendationsApplied } = this.readSynthesisMetrics();
 
     const cyclesCompleted = cycles.filter((c) => c.state === 'complete').length;
@@ -298,6 +298,20 @@ export class BeltCalculator {
     if (!dir || !existsSync(dir)) return 0;
     try {
       return readdirSync(dir).filter((f) => f.endsWith('.json')).length;
+    } catch { return 0; }
+  }
+
+  /**
+   * Count dojo sessions by scanning for subdirectories that contain a meta.json file.
+   * SessionStore stores each session as <sessionsDir>/<uuid>/meta.json — not as a
+   * flat .json file — so countJsonFiles() would only find index.json (always 1).
+   */
+  private countDojoSessions(dir?: string): number {
+    if (!dir || !existsSync(dir)) return 0;
+    try {
+      return readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && existsSync(join(dir, entry.name, 'meta.json')))
+        .length;
     } catch { return 0; }
   }
 }

--- a/src/features/cycle-management/cooldown-session.test.ts
+++ b/src/features/cycle-management/cooldown-session.test.ts
@@ -770,6 +770,125 @@ describe('CooldownSession', () => {
     });
   });
 
+  describe('run with dojoSessionBuilder (dojo session generation)', () => {
+    const dojoDir = join(baseDir, 'dojo-session-gen');
+    const sessionsDir = join(dojoDir, 'sessions');
+
+    beforeEach(() => {
+      mkdirSync(sessionsDir, { recursive: true });
+      mkdirSync(join(dojoDir, 'diary'), { recursive: true });
+    });
+
+    it('generates a dojo session on run() when dojoSessionBuilder is provided', async () => {
+      const { SessionStore } = await import('@infra/dojo/session-store.js');
+      const { SessionBuilder } = await import('@features/dojo/session-builder.js');
+      const sessionStore = new SessionStore(sessionsDir);
+      const dojoSessionBuilder = new SessionBuilder({ sessionStore });
+
+      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Session Gen Cycle');
+
+      const sessionWithDojo = new CooldownSession({
+        cycleManager,
+        knowledgeStore,
+        persistence: JsonStore,
+        pipelineDir,
+        historyDir,
+        dojoDir,
+        dojoSessionBuilder,
+      });
+
+      await sessionWithDojo.run(cycle.id);
+
+      const sessions = sessionStore.list();
+      expect(sessions.length).toBe(1);
+      expect(sessions[0]!.title).toContain('Session Gen Cycle');
+    });
+
+    it('does not generate a dojo session when dojoSessionBuilder is omitted (backward compat)', async () => {
+      const { SessionStore } = await import('@infra/dojo/session-store.js');
+      const sessionStore = new SessionStore(sessionsDir);
+
+      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'No Session');
+
+      const sessionWithDojoNoBuilder = new CooldownSession({
+        cycleManager,
+        knowledgeStore,
+        persistence: JsonStore,
+        pipelineDir,
+        historyDir,
+        dojoDir,
+        // no dojoSessionBuilder
+      });
+
+      await sessionWithDojoNoBuilder.run(cycle.id);
+
+      const sessions = sessionStore.list();
+      expect(sessions.length).toBe(0);
+    });
+
+    it('does not abort cooldown when dojo session generation fails', async () => {
+      const failingBuilder = {
+        build: () => { throw new Error('SessionBuilder exploded'); },
+      };
+
+      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Fail Session');
+
+      const sessionWithBadBuilder = new CooldownSession({
+        cycleManager,
+        knowledgeStore,
+        persistence: JsonStore,
+        pipelineDir,
+        historyDir,
+        dojoDir,
+        dojoSessionBuilder: failingBuilder,
+      });
+
+      // Should not throw
+      const result = await sessionWithBadBuilder.run(cycle.id);
+      expect(result.report).toBeDefined();
+      expect(cycleManager.get(cycle.id).state).toBe('complete');
+    });
+  });
+
+  describe('complete() with dojoSessionBuilder (dojo session generation)', () => {
+    const dojoDir = join(baseDir, 'dojo-session-complete');
+    const sessionsDir = join(dojoDir, 'sessions');
+    const synthesisDir = join(baseDir, 'synthesis-complete');
+
+    beforeEach(() => {
+      mkdirSync(sessionsDir, { recursive: true });
+      mkdirSync(join(dojoDir, 'diary'), { recursive: true });
+      mkdirSync(synthesisDir, { recursive: true });
+    });
+
+    it('generates a dojo session on complete() when dojoSessionBuilder is provided', async () => {
+      const { SessionStore } = await import('@infra/dojo/session-store.js');
+      const { SessionBuilder } = await import('@features/dojo/session-builder.js');
+      const sessionStore = new SessionStore(sessionsDir);
+      const dojoSessionBuilder = new SessionBuilder({ sessionStore });
+
+      // First prepare the cycle (transitions to cooldown state)
+      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Complete Session Cycle');
+      const sessionForComplete = new CooldownSession({
+        cycleManager,
+        knowledgeStore,
+        persistence: JsonStore,
+        pipelineDir,
+        historyDir,
+        dojoDir,
+        synthesisDir,
+        dojoSessionBuilder,
+      });
+
+      await sessionForComplete.prepare(cycle.id);
+      await sessionForComplete.complete(cycle.id);
+
+      const sessions = sessionStore.list();
+      expect(sessions.length).toBeGreaterThanOrEqual(1);
+      expect(sessions[0]!.title).toContain('Complete Session Cycle');
+    });
+  });
+
   describe('run with ruleRegistry (ruleSuggestions)', () => {
     const rulesDir = join(baseDir, 'rules');
 

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -10,6 +10,8 @@ import type { RuleSuggestion } from '@domain/types/rule.js';
 import { ExecutionHistoryEntrySchema } from '@domain/types/history.js';
 import { DiaryWriter } from '@features/dojo/diary-writer.js';
 import { DiaryStore } from '@infra/dojo/diary-store.js';
+import type { SessionBuilder } from '@features/dojo/session-builder.js';
+import { DataAggregator } from '@features/dojo/data-aggregator.js';
 import { logger } from '@shared/lib/logger.js';
 import { loadRunSummary } from './run-summary-loader.js';
 import { ProposalGenerator, type CycleProposal, type ProposalGeneratorDeps } from './proposal-generator.js';
@@ -139,6 +141,13 @@ export interface CooldownSessionDeps {
    * Primarily used for testing to inject mock claude/gh invocations.
    */
   nextKeikoGeneratorDeps?: NextKeikoProposalGeneratorDeps;
+  /**
+   * Optional SessionBuilder for generating a dojo session during cooldown complete.
+   * When provided (alongside dojoDir), CooldownSession generates a DojoSession that
+   * satisfies the belt criterion dojoSessionsGenerated >= N.
+   * Backward compatible — omitting this field skips dojo session generation.
+   */
+  dojoSessionBuilder?: Pick<SessionBuilder, 'build'>;
 }
 
 /**
@@ -388,6 +397,11 @@ export class CooldownSession {
         });
       }
 
+      // 8.6. Generate dojo session (non-critical — satisfies belt criterion dojoSessionsGenerated)
+      if (this.deps.dojoDir && this.deps.dojoSessionBuilder) {
+        this.writeDojoSession(cycleId, cycle.name);
+      }
+
       // 8g. Generate LLM-driven next-keiko proposals (non-critical)
       const nextKeikoResult = this.runNextKeikoProposals(cycle);
 
@@ -608,6 +622,11 @@ export class CooldownSession {
           ? CooldownSession.buildAgentPerspectiveFromProposals(synthesisProposals)
           : undefined,
       });
+    }
+
+    // Generate dojo session (non-critical — satisfies belt criterion dojoSessionsGenerated)
+    if (this.deps.dojoDir && this.deps.dojoSessionBuilder) {
+      this.writeDojoSession(cycleId, cycle.name);
     }
 
     // 8e. Compute belt advancement (non-critical)
@@ -1190,6 +1209,40 @@ export class CooldownSession {
       });
     } catch (err) {
       logger.warn(`Failed to write dojo diary entry: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Generate a DojoSession record for this cooldown.
+   *
+   * Constructs a DataAggregator from available deps, gathers cycle data, then
+   * delegates to the injected dojoSessionBuilder (already wired with its SessionStore).
+   * Non-critical — any error is caught and logged so it never aborts cooldown.
+   *
+   * Requires: dojoDir and dojoSessionBuilder both set in deps.
+   */
+  private writeDojoSession(cycleId: string, cycleName?: string): void {
+    try {
+      const dojoDir = this.deps.dojoDir!;
+      const diaryDir = join(dojoDir, 'diary');
+      const diaryStore = new DiaryStore(diaryDir);
+
+      const aggregator = new DataAggregator({
+        knowledgeStore: this.deps.knowledgeStore as import('@features/dojo/data-aggregator.js').IDojoKnowledgeStore,
+        diaryStore,
+        cycleManager: this.deps.cycleManager,
+        runsDir: this.deps.runsDir ?? join(dojoDir, '..', 'runs'),
+      });
+
+      const data = aggregator.gather({ maxDiaries: 5 });
+
+      const title = cycleName
+        ? `Cooldown — ${cycleName}`
+        : `Cooldown — ${cycleId.slice(0, 8)}`;
+
+      this.deps.dojoSessionBuilder!.build(data, { title });
+    } catch (err) {
+      logger.warn(`Failed to generate dojo session: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add dojoSessionBuilder dep to CooldownSessionDeps; when provided alongside dojoDir, CooldownSession.run() and .complete() both call writeDojoSession() after the diary write, generating a full DojoSession record via DataAggregator + SessionBuilder.
- Fix BeltCalculator.countDojoSessions(): sessions are stored as subdirectories (sessionsDir/uuid/meta.json), not flat JSON files. Old countJsonFiles() only found index.json (always 1). New method counts directories containing meta.json.
- Wire SessionBuilder into both cooldown CLI paths (cooldown id and cooldown complete id).

## Test plan

- Updated belt-calculator.test.ts: counts dojo sessions by subdirectory structure; verifies index.json at root is NOT counted as a session.
- Added 4 new cooldown-session.test.ts tests: session generated on run(), not generated when builder omitted (backward compat), non-critical failure does not abort cooldown, session generated on complete().
- Full test suite: 3170 passed, 8 pre-existing timeouts in cycle.test.ts cooldown block (NextKeikoProposalGenerator spawning claude CLI; pre-existed this PR).

Closes #343