### PR TITLE
feat: document REST API pattern for PR ops in agent context (#358)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,26 @@ src/
 
 Colocated: `*.test.ts` next to `*.ts`. Vitest globals enabled — no need to import `describe`/`it`/`expect`. Coverage excludes test files and `src/cli/index.ts`.
 
+## GitHub PR operations — use REST API
+
+`gh pr create`, `gh pr view --json`, and `gh pr merge` all use GitHub GraphQL (5000/hr quota). With parallel agents this drains fast. Always use the REST API for PR operations during agent runs:
+
+```bash
+# Create PR
+gh api repos/{owner}/{repo}/pulls -X POST \
+  --field title="..." --field body="..." \
+  --field head="branch-name" --field base="main"
+
+# Get PR number by branch
+gh api "repos/{owner}/{repo}/pulls?head={owner}:branch-name"
+
+# Merge PR
+gh api repos/{owner}/{repo}/pulls/NNN/merge -X PUT --field merge_method=squash
+
+# List reviews
+gh api repos/{owner}/{repo}/pulls/NNN/reviews
+```
+
 ## Implementation status
 
 **Keiko 5 complete.** ~3013 tests across 147 files. San-Ma three-space architecture (Epic #261) is the current unblocked epic. See `memory/MEMORY.md` for current state and open issues, `docs/pipeline/plan.md` for wave structure.

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -209,6 +209,29 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
     lines.push(`  export KATA_RUN_ID=${prepared.runId}`);
     lines.push('');
 
+    // PR operations — REST API
+    lines.push('### PR operations — use REST API, not GraphQL');
+    lines.push('`gh pr create`, `gh pr view --json`, and `gh pr merge` all use GitHub GraphQL (5000/hr quota).');
+    lines.push('With parallel agents, this quota drains fast. **Use REST API for all PR operations:**');
+    lines.push('');
+    lines.push('```bash');
+    lines.push('# Create PR');
+    lines.push('gh api repos/{owner}/{repo}/pulls -X POST \\');
+    lines.push('  --field title="..." --field body="..." \\');
+    lines.push('  --field head="branch-name" --field base="main"');
+    lines.push('');
+    lines.push('# Get PR number by branch');
+    lines.push('gh api "repos/{owner}/{repo}/pulls?head={owner}:branch-name"');
+    lines.push('');
+    lines.push('# Merge PR');
+    lines.push('gh api repos/{owner}/{repo}/pulls/NNN/merge -X PUT \\');
+    lines.push('  --field merge_method=squash');
+    lines.push('');
+    lines.push('# List PR reviews');
+    lines.push('gh api repos/{owner}/{repo}/pulls/NNN/reviews');
+    lines.push('```');
+    lines.push('');
+
     // Record as you work
     lines.push('### Record as you work');
     lines.push('Use these commands at natural checkpoints — when a decision matters, when something surprises you, when you hit resistance:');


### PR DESCRIPTION
## Summary

- Adds a "PR operations" section to `formatAgentContext()` in `session-bridge.ts` so every agent run sees REST API alternatives to `gh pr` subcommands
- Updates `CLAUDE.md` with the same REST API guidance for interactive sessions
- Prevents GraphQL quota exhaustion (5000/hr) during parallel agent keiko runs

## What changed

**`src/infrastructure/execution/session-bridge.ts`** — new section injected after "Git workflow" in `formatAgentContext()`:
- Explains WHY (GraphQL rate limit with parallel agents)
- Provides copy-paste REST commands for create, get, merge, and list-reviews

**`CLAUDE.md`** — new "GitHub PR operations" section with the same REST patterns for interactive use

## Test plan

- [ ] Run `kata kiai context <run-id>` and verify the "PR operations" section appears in output
- [ ] Confirm TypeScript compiles clean (`npm run typecheck`)
- [ ] Confirm lint passes (`npm run lint\`)

Closes #358

Generated with Claude Code (claude-sonnet-4-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance on GitHub PR operations with REST API best practices and command examples.
  * Added clearer instructions for pull request actions to optimize performance and prevent API quota limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->