### PR TITLE
fix: tighten write-barrier hook — 2>&1, /dev/null, git false-positives (#357, #359)

### DIFF
--- a/.claude/hooks/block-write-outside-worktree.sh
+++ b/.claude/hooks/block-write-outside-worktree.sh
@@ -141,22 +141,32 @@ fi
 if [[ "$TOOL_NAME" == "Bash" ]]; then
   COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
 
-  # Allow git-only commands (optionally preceded by env-var exports like
-  # "export KATA_RUN_ID=...; git commit ..."). Git writes only to .git/
-  # internals — branch names containing '/' are not filesystem paths.
-  # Only bypasses when the remaining command after exports is a single git
-  # invocation with no shell chaining (no ; && || |).
+  # Allow safe git subcommands (optionally preceded by env-var exports like
+  # "export KATA_RUN_ID=...; git commit ..."). Only an explicit allowlist of
+  # subcommands that write exclusively to .git/ internals or the worktree are
+  # permitted. Dangerous subcommands (clone, init, worktree, archive) that can
+  # write to arbitrary paths fall through to normal blocking. Shell chaining
+  # (;&|) also falls through.
   _cmd_after_exports=$(printf '%s' "$COMMAND" \
     | sed -E 's/^([[:space:]]*(export [A-Za-z_][A-Za-z0-9_]*=[^;]*;[[:space:]]*)*)//')
-  if printf '%s' "$_cmd_after_exports" | grep -qE '^git[[:space:]]' && \
-     ! printf '%s' "$_cmd_after_exports" | grep -qE '[;&|]'; then
-    exit 0
+  if ! printf '%s' "$_cmd_after_exports" | grep -qE '[;&|]'; then
+    _git_sub=$(printf '%s' "$_cmd_after_exports" \
+      | sed -E 's/^git[[:space:]]+([a-z-]+).*/\1/')
+    case "$_git_sub" in
+      add|checkout|commit|branch|push|fetch|pull|status|log|diff|show|\
+      tag|stash|rebase|merge|reset|restore|switch|rev-parse|symbolic-ref|\
+      config|remote|describe|shortlog|blame|format-patch|am|apply|cherry-pick)
+        exit 0 ;;
+    esac
   fi
 
   while IFS= read -r candidate; do
     [[ -z "$candidate" ]] && continue
-    # Exclude /dev/* — device files (e.g. /dev/null) are never real write targets
-    [[ "$candidate" == /dev/* ]] && continue
+    # Exclude only known sink pseudo-files — /dev/null and stdio aliases.
+    # /dev/shm and other writable /dev paths must still be checked.
+    case "$candidate" in
+      /dev/null|/dev/stdin|/dev/stdout|/dev/stderr|/dev/fd/*) continue ;;
+    esac
     is_outside_worktree "$candidate" || continue
     # Write tokens: >> and > (but NOT >& which is fd duplication like 2>&1)
     if printf '%s' "$COMMAND" | grep -qE \


### PR DESCRIPTION
## Summary

Three targeted fixes to the PreToolUse write-barrier hook.

**Fix 1 — 2>&1 false-positive (#357)**
Replaced the bare `>` write-token (`>>?`) with `>>|>[^&>]`. This stops matching `>` in `2>&1` (fd duplication) while still catching actual file redirects (`> file`, `>> file`, `>/path`).

**Fix 2 — /dev/null false-positive (#357)**
Added `[[ "$candidate" == /dev/* ]] && continue` to skip device files extracted from commands like `2>/dev/null`. Device files are never real write targets.

**Fix 3 — git ops in nested worktrees (#359)**
Added a bypass for single git invocations (optionally preceded by `export VAR=val;`). Git only writes to `.git/` internals — branch names like `keiko-abc/fix-something` contain `/` but are not filesystem paths. Shell chaining (`;&|`) falls through to normal blocking.

## Test plan

- Command `some-cmd 2>&1` — no longer blocked when path is extracted
- Command `echo foo 2>/dev/null` — no longer blocked
- Command `export KATA_RUN_ID=abc; git commit -m msg` — allowed
- Command `git checkout -b keiko-abc/branch-name` — allowed
- Command `git status && echo foo > /main/file` — still blocked (has `&&`)
- Command `echo foo > /outside/file` — still blocked

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal validation logic for better detection and handling of system commands and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->