### PR TITLE
fix: cooldown --yolo silent output, diary truncation, kime vs kansatsu docs

### DIFF
--- a/src/cli/commands/cycle.test.ts
+++ b/src/cli/commands/cycle.test.ts
@@ -1231,6 +1231,36 @@ describe('registerCycleCommands', () => {
       expect(state.ranWithYolo).toBe(true);
     }, 30000);
 
+    // Issue #336 — --yolo non-JSON mode must emit cycle header before any async ops.
+    // Previously the first stdout output was from formatCooldownSessionResult() — only
+    // visible after prepare() + synthesis completed. If complete() threw, there was zero
+    // stdout. Fix: emit "Cooldown (--yolo): <name> — N bet(s)" immediately (#336).
+    it('--yolo non-JSON mode emits cycle name and bet count as header before prepare', async () => {
+      const manager = new CycleManager(cyclesDir, JsonStore);
+      const cycle = manager.create({ tokenBudget: 50000 }, 'Yolo Header Test');
+
+      const synthesisDir = join(kataDir, 'synthesis');
+      mkdirSync(synthesisDir, { recursive: true });
+
+      const originalPath = process.env['PATH'];
+      process.env['PATH'] = '';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node', 'test', '--plain', '--cwd', baseDir,
+        'cooldown', cycle.id, '--yolo',
+      ]);
+
+      process.env['PATH'] = originalPath;
+      warnSpy.mockRestore();
+
+      // Cycle header must appear on stdout (first or early call)
+      const stdoutCalls = consoleSpy.mock.calls.map((c) => c[0] as string).join('\n');
+      expect(stdoutCalls).toContain('Cooldown (--yolo): Yolo Header Test');
+      expect(stdoutCalls).toContain('0 bet(s)');
+    }, 30000);
+
     it('--auto-accept-suggestions includes suggestionReview in --json output', async () => {
       const { RuleRegistry } = await import('@infra/registries/rule-registry.js');
       const rulesDir = join(kataDir, 'rules');

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -1008,6 +1008,16 @@ export function registerCycleCommands(parent: Command): void {
 
       // --- --yolo mode: prepare + claude for synthesis + apply high-confidence proposals ---
       if (localOpts.yolo) {
+        // Emit cycle header immediately — before any async ops — so there is always
+        // visible stdout output even if prepare() or complete() fail (#336).
+        if (!ctx.globalOpts.json) {
+          const cycleForHeader = manager.get(cycleId);
+          const cycleLabelForHeader = cycleForHeader.name ?? cycleId.slice(0, 8);
+          const betCountForHeader = cycleForHeader.bets.length;
+          console.log(`Cooldown (--yolo): ${cycleLabelForHeader} — ${betCountForHeader} bet(s)`);
+          console.log('');
+        }
+
         // Outer try/catch: ensures --json mode always emits a valid JSON object to
         // stdout even when prepare() or complete() throw (fixes #257 — silent failure).
         let prepareResult: Awaited<ReturnType<typeof session.prepare>>;
@@ -1086,6 +1096,10 @@ export function registerCycleCommands(parent: Command): void {
           // Both modes surface the error — non-JSON to stderr, JSON carries it in the
           // synthesisError field of the output object (emitted below after complete()).
           console.warn(`Warning: --yolo synthesis failure: ${msg}. Completing without proposals.`);
+        }
+
+        if (!ctx.globalOpts.json) {
+          console.log(`Synthesis complete: ${synthesisProposals.length} proposal(s) generated.`);
         }
 
         // Apply only high-confidence proposals (confidence > 0.8)

--- a/src/cli/formatters/dojo-formatter.test.ts
+++ b/src/cli/formatters/dojo-formatter.test.ts
@@ -106,10 +106,18 @@ describe('formatDojoDiaryTable', () => {
     expect(result).toContain('Pain points: 1');
   });
 
-  it('truncates long narratives to 80 chars', () => {
-    const longNarrative = 'A'.repeat(100);
+  it('truncates long narratives to 500 chars', () => {
+    const longNarrative = 'A'.repeat(600);
     const result = formatDojoDiaryTable([makeDiaryEntry({ narrative: longNarrative })]);
     expect(result).toContain('...');
+    // Verify truncation is at 500, not earlier
+    expect(result).toContain('A'.repeat(500));
+  });
+
+  it('does not truncate narratives under 500 chars', () => {
+    const shortNarrative = 'A'.repeat(400);
+    const result = formatDojoDiaryTable([makeDiaryEntry({ narrative: shortNarrative })]);
+    expect(result).not.toContain('...');
   });
 
   it('uses cycleId prefix when cycleName is absent', () => {

--- a/src/cli/formatters/dojo-formatter.ts
+++ b/src/cli/formatters/dojo-formatter.ts
@@ -49,7 +49,7 @@ export function formatDojoDiaryTable(entries: DojoDiaryEntry[], plain?: boolean)
     const mood = e.mood ? ` (${e.mood})` : '';
     const name = e.cycleName ?? e.cycleId.slice(0, 8);
     lines.push(`  ${date}  ${name}${mood}`);
-    lines.push(`           ${e.narrative.slice(0, 80)}${e.narrative.length > 80 ? '...' : ''}`);
+    lines.push(`           ${e.narrative.slice(0, 500)}${e.narrative.length > 500 ? '...' : ''}`);
     if (e.wins.length > 0) lines.push(`           Wins: ${e.wins.length}`);
     if (e.painPoints.length > 0) lines.push(`           Pain points: ${e.painPoints.length}`);
   }

--- a/src/infrastructure/execution/session-bridge.test.ts
+++ b/src/infrastructure/execution/session-bridge.test.ts
@@ -400,6 +400,23 @@ describe('SessionExecutionBridge', () => {
       expect(context).toContain(`export KATA_RUN_ID=${prepared.runId}`);
     });
 
+    it('clarifies kime vs kansatsu for decision recording (#347)', () => {
+      const cycle = createCycle(kataDir);
+      const bridge = new SessionExecutionBridge(kataDir);
+      const prepared = bridge.prepare(cycle.bets[0]!.id);
+
+      const context = bridge.formatAgentContext(prepared);
+
+      // kime vs kansatsu guidance must be present
+      expect(context).toContain('kime vs kansatsu');
+      // kime is the primary belt metric
+      expect(context).toContain('Belt advancement tracks these directly');
+      // kansatsu decision/outcome is the secondary signal
+      expect(context).toContain('secondary signal');
+      // clear recommendation to prefer kime
+      expect(context).toContain('Prefer `kime record`');
+    });
+
     it('should slugify bet name in branch suggestion (#237)', () => {
       const betId = randomUUID();
       createCycle(kataDir, {

--- a/src/infrastructure/execution/session-bridge.ts
+++ b/src/infrastructure/execution/session-bridge.ts
@@ -218,6 +218,16 @@ export class SessionExecutionBridge implements ISessionExecutionBridge {
     lines.push(`  kata --cwd ${repoRoot} kime record --decision "..." --rationale "..." --run ${prepared.runId}`);
 
     lines.push('');
+    lines.push('**kime vs kansatsu — which to use for decisions:**');
+    lines.push('  `kime record` is for decisions with explicit, trackable outcomes. Use kime when:');
+    lines.push('    - You make a significant architectural or approach decision');
+    lines.push('    - You can state what "success" or "failure" looks like for this decision');
+    lines.push('    - Belt advancement tracks these directly as decision-outcome pairs');
+    lines.push('  `kansatsu record decision` + `kansatsu record outcome` is for paired run observations. Use when:');
+    lines.push('    - You want to log a decision as part of a broader observational record');
+    lines.push('    - Belt also counts these as min(decisions, outcomes) pairs — secondary signal');
+    lines.push('  **Prefer `kime record` for significant decisions — it is the primary belt metric.**');
+    lines.push('');
     lines.push('**Observation types** — pick the most specific:');
     lines.push('  decision    — a choice between real alternatives; always include WHY you chose this path');
     lines.push('  prediction  — a testable bet about future behavior (state what would falsify it)');


### PR DESCRIPTION
## Summary

- **#336 — --yolo silent output**: Emit cycle name + bet count header immediately at the start of the --yolo block, before any async operations. Previously, if complete() threw, zero stdout was produced. Also adds a synthesis result count line after the claude subprocess finishes.

- **#345 — diary truncation**: Increase narrative truncation in formatDojoDiaryTable() from 80 to 500 characters. The full content exists in JSON but the 80-char cutoff was too aggressive for useful terminal display. Test updated to assert the 500-char boundary.

- **#347 — kime vs kansatsu guidance**: Add a kime vs kansatsu section to formatAgentContext() in session-bridge.ts. Clarifies that kime record is the primary belt metric (decision-outcome pairs counted directly), while kansatsu record decision/outcome is a secondary signal (counted as min pairs). Directs agents to prefer kime record for significant decisions.

## Test plan

- [ ] --yolo test: new test asserts cycle header appears on stdout even when synthesis fails (PATH cleared)
- [ ] Diary truncation: updated test asserts truncation at 500 chars, not 80
- [ ] Agent context: new test asserts kime vs kansatsu guidance, primary belt metric mention, secondary signal language
- [ ] All existing cycle, dojo-formatter, and session-bridge tests pass
