### PR TITLE
fix: synthesis stale files, diary overwrite, and empty proposals

### DIFF
--- a/src/features/cycle-management/cooldown-session-prepare.test.ts
+++ b/src/features/cycle-management/cooldown-session-prepare.test.ts
@@ -622,4 +622,51 @@ describe('CooldownSession.prepare() — observation wiring', () => {
     const input = SynthesisInputSchema.parse(JSON.parse(raw));
     expect(input.observations).toHaveLength(0);
   });
+
+  describe('stale synthesis input cleanup (#330)', () => {
+    it('removes a previous pending file for the same cycleId before writing a new one', async () => {
+      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Stale Cleanup Test');
+      const sessionA = new CooldownSession(makeDeps());
+
+      // First --prepare run
+      const first = await sessionA.prepare(cycle.id);
+      expect(existsSync(first.synthesisInputPath)).toBe(true);
+
+      // Reset to active so we can prepare again
+      cycleManager.updateState(cycle.id, 'active');
+
+      // Second --prepare run — stale file from first run should be removed
+      const sessionA2 = new CooldownSession(makeDeps());
+      const second = await sessionA2.prepare(cycle.id);
+      expect(existsSync(second.synthesisInputPath)).toBe(true);
+      expect(first.synthesisInputId).not.toBe(second.synthesisInputId);
+
+      // The first pending file must be gone
+      expect(existsSync(first.synthesisInputPath)).toBe(false);
+    });
+
+    it('only removes pending files matching the current cycleId, not other cycles', async () => {
+      const cycleA = cycleManager.create({ tokenBudget: 50000 }, 'Cycle A');
+      const cycleB = cycleManager.create({ tokenBudget: 50000 }, 'Cycle B');
+      const sessionA = new CooldownSession(makeDeps());
+      const sessionB = new CooldownSession(makeDeps());
+
+      const resultA = await sessionA.prepare(cycleA.id);
+      const resultB = await sessionB.prepare(cycleB.id);
+
+      // Both pending files should still exist at this point
+      expect(existsSync(resultA.synthesisInputPath)).toBe(true);
+      expect(existsSync(resultB.synthesisInputPath)).toBe(true);
+
+      // Re-prepare cycleA — should only remove cycleA's stale file
+      cycleManager.updateState(cycleA.id, 'active');
+      const sessionA2 = new CooldownSession(makeDeps());
+      const resultA2 = await sessionA2.prepare(cycleA.id);
+
+      expect(existsSync(resultA.synthesisInputPath)).toBe(false);
+      expect(existsSync(resultA2.synthesisInputPath)).toBe(true);
+      // CycleB's file must remain untouched
+      expect(existsSync(resultB.synthesisInputPath)).toBe(true);
+    });
+  });
 });

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
 import type { CycleManager, CooldownReport } from '@domain/services/cycle-manager.js';
 import type { IKnowledgeStore } from '@domain/ports/knowledge-store.js';
 import type { IPersistence } from '@domain/ports/persistence.js';
@@ -791,6 +791,27 @@ export class CooldownSession {
       tokenBudget: report.budget.tokenBudget,
       tokensUsed: report.tokensUsed,
     };
+
+    // Clean up stale pending synthesis files for the same cycleId (#330).
+    // Running --prepare multiple times would otherwise accumulate files and
+    // confuse `cooldown complete` about which is current.
+    try {
+      const existing = readdirSync(synthesisDir).filter((f) => f.startsWith('pending-') && f.endsWith('.json'));
+      for (const file of existing) {
+        try {
+          const raw = readFileSync(join(synthesisDir, file), 'utf-8');
+          const meta = JSON.parse(raw) as { cycleId?: string };
+          if (meta.cycleId === cycleId) {
+            unlinkSync(join(synthesisDir, file));
+            logger.debug(`Removed stale synthesis input file: ${file}`);
+          }
+        } catch {
+          // Skip unreadable / already-deleted files
+        }
+      }
+    } catch {
+      // Non-critical — if cleanup fails, still write the new file
+    }
 
     const filePath = join(synthesisDir, `pending-${id}.json`);
     JsonStore.write(filePath, synthesisInput, SynthesisInputSchema);

--- a/src/features/cycle-management/next-keiko-proposal-generator.ts
+++ b/src/features/cycle-management/next-keiko-proposal-generator.ts
@@ -102,6 +102,29 @@ export class NextKeikoProposalGenerator {
     // 1. Collect observations from all cycle runs
     const observations = this.collectObservations(input.cycle, input.runsDir, input.bridgeRunsDir);
 
+    // Log observation counts so empty-proposal failures are visible (#342).
+    // When observations are 0, proposals will still be generated from milestone issues
+    // and completed bets, but the signal is weak — this surfaces the situation clearly.
+    const betsWithRunIds = input.cycle.bets.filter((b) => b.runId).length;
+    if (observations.length === 0) {
+      if (betsWithRunIds === 0) {
+        logger.warn(
+          `NextKeikoProposalGenerator: no observations found — cycle has ${input.cycle.bets.length} bet(s) but none have runIds. ` +
+          `Proposals will rely on milestone issues and completed bet descriptions only.`,
+        );
+      } else {
+        logger.warn(
+          `NextKeikoProposalGenerator: no observations found across ${betsWithRunIds} run(s). ` +
+          `Agents may not have recorded observations during this cycle. ` +
+          `Proposals will rely on milestone issues and completed bet descriptions only.`,
+        );
+      }
+    } else {
+      logger.debug(
+        `NextKeikoProposalGenerator: collected ${observations.length} observation(s) from ${betsWithRunIds} run(s).`,
+      );
+    }
+
     const frictionObs = observations.filter((o) => o.type === 'friction');
     const gapObs = observations.filter((o) => o.type === 'gap');
     const insightObs = observations.filter((o) => o.type === 'insight');

--- a/src/features/dojo/diary-writer.ts
+++ b/src/features/dojo/diary-writer.ts
@@ -50,7 +50,10 @@ export class DiaryWriter {
       updatedAt: new Date().toISOString(),
     });
 
-    this.store.write(entry);
+    // Use upsert so re-running cooldown on the same cycle merges rather than overwrites (#331).
+    // On first write this behaves identically to write(); on subsequent writes it preserves
+    // the original `id`/`createdAt` and fills in perspective fields only when provided.
+    this.store.upsert(entry);
     return entry;
   }
 

--- a/src/infrastructure/dojo/diary-store.test.ts
+++ b/src/infrastructure/dojo/diary-store.test.ts
@@ -111,6 +111,96 @@ describe('DiaryStore', () => {
     });
   });
 
+  describe('upsert', () => {
+    it('writes a new entry when none exists for the cycleId', () => {
+      const entry = makeDiaryEntry({ narrative: 'First pass' });
+      store.upsert(entry);
+
+      const result = store.readByCycleId(entry.cycleId);
+      expect(result).not.toBeNull();
+      expect(result!.narrative).toBe('First pass');
+      expect(result!.id).toBe(entry.id);
+    });
+
+    it('preserves id and createdAt from the original entry on update (#331)', () => {
+      const cycleId = crypto.randomUUID();
+      const originalCreatedAt = '2026-01-01T00:00:00.000Z';
+      const first = makeDiaryEntry({ cycleId, createdAt: originalCreatedAt, narrative: 'First pass' });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId, narrative: 'Second pass' });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.id).toBe(first.id);
+      expect(result!.createdAt).toBe(originalCreatedAt);
+    });
+
+    it('overwrites deterministic fields with the latest values', () => {
+      const cycleId = crypto.randomUUID();
+      const first = makeDiaryEntry({ cycleId, narrative: 'First', wins: ['win1'], painPoints: ['pain1'], tags: ['a'] });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId, narrative: 'Second', wins: ['win2'], painPoints: [], tags: ['b', 'c'] });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.narrative).toBe('Second');
+      expect(result!.wins).toEqual(['win2']);
+      expect(result!.painPoints).toEqual([]);
+      expect(result!.tags).toEqual(['b', 'c']);
+    });
+
+    it('preserves agentPerspective from earlier write when the new entry has none', () => {
+      const cycleId = crypto.randomUUID();
+      const first = makeDiaryEntry({ cycleId, agentPerspective: 'Agent insight from prepare' });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId, agentPerspective: undefined });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.agentPerspective).toBe('Agent insight from prepare');
+    });
+
+    it('updates agentPerspective when the new entry provides it', () => {
+      const cycleId = crypto.randomUUID();
+      const first = makeDiaryEntry({ cycleId, agentPerspective: 'Old agent insight' });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId, agentPerspective: 'New agent insight from synthesis' });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.agentPerspective).toBe('New agent insight from synthesis');
+    });
+
+    it('preserves humanPerspective from earlier write when the new entry has none', () => {
+      const cycleId = crypto.randomUUID();
+      const first = makeDiaryEntry({ cycleId, humanPerspective: 'Human reflection' });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId, humanPerspective: undefined });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.humanPerspective).toBe('Human reflection');
+    });
+
+    it('sets updatedAt on merge to a value >= createdAt', () => {
+      const cycleId = crypto.randomUUID();
+      const first = makeDiaryEntry({ cycleId, createdAt: '2026-01-01T00:00:00.000Z' });
+      store.upsert(first);
+
+      const second = makeDiaryEntry({ cycleId });
+      store.upsert(second);
+
+      const result = store.readByCycleId(cycleId);
+      expect(result!.updatedAt).toBeDefined();
+      expect(result!.updatedAt! >= result!.createdAt).toBe(true);
+    });
+  });
+
   describe('list', () => {
     it('returns an empty array when no entries exist', () => {
       const result = store.list();

--- a/src/infrastructure/dojo/diary-store.ts
+++ b/src/infrastructure/dojo/diary-store.ts
@@ -11,6 +11,53 @@ export class DiaryStore {
     JsonStore.write(filePath, parsed, DojoDiaryEntrySchema);
   }
 
+  /**
+   * Merge a new diary entry into an existing one for the same cycleId (#331).
+   *
+   * Strategy:
+   *   - Preserve `id` and `createdAt` from the existing entry so file identity is stable.
+   *   - Overwrite `rawDataSummary`, `narrative`, `wins`, `painPoints`, `openQuestions`,
+   *     `mood`, and `tags` with the new values (derived deterministically from current
+   *     cycle state and should always reflect the latest run).
+   *   - Fill in `agentPerspective` / `humanPerspective` only when the new entry provides
+   *     them; otherwise keep the existing value so a `--prepare` followed by `complete`
+   *     does not lose the perspective written by the first pass.
+   *   - Always update `updatedAt` to now.
+   *
+   * When no existing entry is found, falls back to a plain write.
+   */
+  upsert(entry: DojoDiaryEntry): void {
+    const existing = this.readByCycleId(entry.cycleId);
+    if (!existing) {
+      this.write(entry);
+      return;
+    }
+
+    const merged: DojoDiaryEntry = {
+      // Identity fields — preserved from the first write
+      id: existing.id,
+      cycleId: existing.cycleId,
+      createdAt: existing.createdAt,
+      // Deterministic fields — always use the latest computed values
+      cycleName: entry.cycleName ?? existing.cycleName,
+      narrative: entry.narrative,
+      wins: entry.wins,
+      painPoints: entry.painPoints,
+      openQuestions: entry.openQuestions,
+      mood: entry.mood,
+      tags: entry.tags,
+      rawDataSummary: entry.rawDataSummary ?? existing.rawDataSummary,
+      // Perspective fields — fill in when newly provided; otherwise keep existing value
+      agentPerspective: entry.agentPerspective ?? existing.agentPerspective,
+      humanPerspective: entry.humanPerspective ?? existing.humanPerspective,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const parsed = DojoDiaryEntrySchema.parse(merged);
+    const filePath = join(this.diaryDir, `${parsed.cycleId}.json`);
+    JsonStore.write(filePath, parsed, DojoDiaryEntrySchema);
+  }
+
   readByCycleId(cycleId: string): DojoDiaryEntry | null {
     const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!UUID_RE.test(cycleId)) return null;


### PR DESCRIPTION
## Summary

- **#330 — Stale synthesis input files**: `writeSynthesisInput()` now scans the synthesis dir for existing `pending-*.json` files belonging to the same `cycleId` and removes them before writing a new one. Re-running `cooldown --prepare` on the same cycle no longer accumulates stale files.
- **#331 — Diary entry overwrite**: Added `DiaryStore.upsert()` which reads any existing diary entry for the same `cycleId` and merges rather than replacing. Identity fields (`id`, `createdAt`) are preserved; perspective fields (`agentPerspective`, `humanPerspective`) are only updated when the new write provides them. `DiaryWriter.write()` now calls `upsert()` instead of `write()`.
- **#342 — Silent empty proposals**: Added warning logs in `NextKeikoProposalGenerator.generate()` when observations are empty, distinguishing "no runIds on bets" from "runIds present but agents recorded no observations". Previously, 0-observation cycles produced proposals silently with no diagnostic output.

## Test plan

- [ ] `cooldown-session-prepare.test.ts` — 2 new tests verify stale file cleanup (same-cycle overwrite; cross-cycle isolation)
- [ ] `diary-store.test.ts` — 7 new tests verify `upsert()` behavior (new entry, id/createdAt preservation, field merge, perspective carry-forward)
- [ ] `next-keiko-proposal-generator.test.ts` — existing 18 tests pass; new warn logging visible in output
- [ ] All 3194 existing tests pass (pre-existing `cycle.test.ts` timeout unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
