### PR TITLE
refactor: remove kataka aliases, injectable registry, wire bridge-run-store

### DIFF
--- a/src/features/cycle-management/bridge-run-syncer.steps.ts
+++ b/src/features/cycle-management/bridge-run-syncer.steps.ts
@@ -75,7 +75,19 @@ function writeBridgeRunFile(
   runId: string,
   meta: Record<string, unknown>,
 ): void {
-  writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify(meta));
+  const base = {
+    runId,
+    betId: meta.betId ?? randomUUID(),
+    betName: 'test bet',
+    cycleId: meta.cycleId ?? randomUUID(),
+    cycleName: 'Test Cycle',
+    stages: ['build'],
+    isolation: 'shared',
+    startedAt: '2026-03-22T10:00:00.000Z',
+    status: 'complete',
+    ...meta,
+  };
+  writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify(base));
 }
 
 function writeRunFile(

--- a/src/features/cycle-management/bridge-run-syncer.test.ts
+++ b/src/features/cycle-management/bridge-run-syncer.test.ts
@@ -53,7 +53,19 @@ function makeDeps(overrides: Partial<BridgeRunSyncerDeps> = {}): BridgeRunSyncer
 }
 
 function writeBridgeRun(dir: string, runId: string, meta: Record<string, unknown>): void {
-  writeFileSync(join(dir, `${runId}.json`), JSON.stringify(meta));
+  const base = {
+    runId,
+    betId: meta.betId ?? randomUUID(),
+    betName: 'test bet',
+    cycleId: meta.cycleId ?? randomUUID(),
+    cycleName: 'Test Cycle',
+    stages: ['build'],
+    isolation: 'shared',
+    startedAt: '2026-03-22T10:00:00.000Z',
+    status: 'complete',
+    ...meta,
+  };
+  writeFileSync(join(dir, `${runId}.json`), JSON.stringify(base));
 }
 
 function writeValidRunFile(dir: string, runId: string, status: string): void {
@@ -386,11 +398,12 @@ describe('BridgeRunSyncer', () => {
       expect(syncer.loadBridgeRunIdsByBetId(randomUUID()).size).toBe(0);
     });
 
-    it('skips files without betId or runId', () => {
+    it('skips files that fail schema validation', () => {
       const cycleId = randomUUID();
       const deps = makeDeps({ bridgeRunsDir });
 
-      writeBridgeRun(bridgeRunsDir, randomUUID(), { cycleId, status: 'complete' });
+      // Write an incomplete object that won't pass BridgeRunMetaSchema
+      writeFileSync(join(bridgeRunsDir, 'incomplete.json'), JSON.stringify({ cycleId, status: 'complete' }));
 
       const syncer = new BridgeRunSyncer(deps);
       expect(syncer.loadBridgeRunIdsByBetId(cycleId).size).toBe(0);

--- a/src/features/cycle-management/bridge-run-syncer.ts
+++ b/src/features/cycle-management/bridge-run-syncer.ts
@@ -1,13 +1,13 @@
 import { join } from 'node:path';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import type { CycleManager } from '@domain/services/cycle-manager.js';
 import { logger } from '@shared/lib/logger.js';
 import { JsonStoreError } from '@infra/persistence/json-store.js';
 import { readRun } from '@infra/persistence/run-store.js';
+import { readBridgeRunMeta, listBridgeRunsForCycle } from '@infra/persistence/bridge-run-store.js';
 import type { BetOutcomeRecord, IncompleteRunInfo } from './cooldown-types.js';
 import {
   collectBridgeRunIds,
-  isJsonFile,
   isSyncableBet,
   mapBridgeRunStatusToIncompleteStatus,
   mapBridgeRunStatusToSyncedOutcome,
@@ -101,10 +101,7 @@ export class BridgeRunSyncer {
    */
   loadBridgeRunIdsByBetId(cycleId: string): Map<string, string> {
     if (!this.deps.bridgeRunsDir) return new Map();
-    const files = this.listJsonFiles(this.deps.bridgeRunsDir);
-    const metas = files
-      .map((file) => this.readBridgeRunMeta(join(this.deps.bridgeRunsDir!, file)))
-      .filter((meta): meta is NonNullable<typeof meta> => meta !== undefined);
+    const metas = listBridgeRunsForCycle(this.deps.bridgeRunsDir, cycleId);
     return collectBridgeRunIds(metas, cycleId);
   }
 
@@ -127,33 +124,8 @@ export class BridgeRunSyncer {
     bridgeRunsDir: string,
     runId: string,
   ): BetOutcomeRecord['outcome'] | undefined {
-    const bridgeRunPath = join(bridgeRunsDir, `${runId}.json`);
-    const status = this.readBridgeRunMeta(bridgeRunPath)?.status;
-    return mapBridgeRunStatusToSyncedOutcome(status);
-  }
-
-  private listJsonFiles(dir: string): string[] {
-    try {
-      // Stryker disable next-line MethodExpression: filter redundant — readBridgeRunMeta catches non-json parse errors
-      return readdirSync(dir).filter(isJsonFile);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.warn(`Unexpected error listing bridge-run directory ${dir}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-      return [];
-    }
-  }
-
-  private readBridgeRunMeta(filePath: string): { cycleId?: string; betId?: string; runId?: string; status?: string } | undefined {
-    try {
-      return JSON.parse(readFileSync(filePath, 'utf-8')) as { cycleId?: string; betId?: string; runId?: string; status?: string };
-    // Stryker disable next-line all: equivalent mutant — catch returns undefined for expected errors
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT' && !(err instanceof SyntaxError)) {
-        logger.warn(`Unexpected error reading bridge-run file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-      return undefined;
-    }
+    const meta = readBridgeRunMeta(bridgeRunsDir, runId);
+    return mapBridgeRunStatusToSyncedOutcome(meta?.status);
   }
 
   private resolveIncompleteRunStatus(
@@ -170,8 +142,8 @@ export class BridgeRunSyncer {
 
     const bridgeRunPath = join(this.deps.bridgeRunsDir, `${runId}.json`);
     if (!existsSync(bridgeRunPath)) return undefined;
-    const status = this.readBridgeRunMeta(bridgeRunPath)?.status;
-    const incompleteStatus = mapBridgeRunStatusToIncompleteStatus(status);
+    const meta = readBridgeRunMeta(this.deps.bridgeRunsDir, runId);
+    const incompleteStatus = mapBridgeRunStatusToIncompleteStatus(meta?.status);
     return incompleteStatus ?? null;
   }
 

--- a/src/features/cycle-management/cooldown-belt-computer.feature
+++ b/src/features/cycle-management/cooldown-belt-computer.feature
@@ -49,12 +49,6 @@ Feature: Belt and agent confidence computation during cooldown
     Then confidence is computed for agent "Alpha"
     And confidence is computed for agent "Beta"
 
-  Scenario: agent confidence supports legacy kataka aliases
-    Given agent confidence tracking is enabled via legacy kataka configuration
-    And agent "Legacy" is registered in the kataka directory
-    When agent confidence computation runs
-    Then confidence is computed for agent "Legacy"
-
   Scenario: agent confidence is skipped when tracking is not enabled
     Given agent confidence tracking is not enabled
     When agent confidence computation runs

--- a/src/features/cycle-management/cooldown-belt-computer.steps.ts
+++ b/src/features/cycle-management/cooldown-belt-computer.steps.ts
@@ -21,9 +21,7 @@ interface CooldownBeltComputerWorld extends QuickPickleWorld {
   beltCalculatorSpy?: { computeAndStore: ReturnType<typeof vi.fn<ComputeAndStoreFn>> };
   projectStateFile?: string;
   agentConfidenceCalculatorSpy?: { compute: ReturnType<typeof vi.fn<ComputeFn>> };
-  katakaConfidenceCalculatorSpy?: { compute: ReturnType<typeof vi.fn<ComputeFn>> };
   agentDir?: string;
-  katakaDir?: string;
   computer?: CooldownBeltComputer;
   beltResult?: BeltComputeResult;
   loggerInfoSpy: ReturnType<typeof vi.fn>;
@@ -55,9 +53,7 @@ function buildComputer(world: CooldownBeltComputerWorld): CooldownBeltComputer {
     beltCalculator: world.beltCalculatorSpy,
     projectStateFile: world.projectStateFile,
     agentConfidenceCalculator: world.agentConfidenceCalculatorSpy,
-    katakaConfidenceCalculator: world.katakaConfidenceCalculatorSpy,
     agentDir: world.agentDir,
-    katakaDir: world.katakaDir,
   };
   return new CooldownBeltComputer(deps);
 }
@@ -145,22 +141,6 @@ Given(
   (world: CooldownBeltComputerWorld, name1: string, name2: string) => {
     writeAgentRecord(world.agentDir!, name1);
     writeAgentRecord(world.agentDir!, name2);
-  },
-);
-
-Given(
-  'agent confidence tracking is enabled via legacy kataka configuration',
-  (world: CooldownBeltComputerWorld) => {
-    world.katakaDir = join(world.tmpDir, 'kataka-agents');
-    mkdirSync(world.katakaDir, { recursive: true });
-    world.katakaConfidenceCalculatorSpy = { compute: vi.fn<ComputeFn>() };
-  },
-);
-
-Given(
-  'agent {string} is registered in the kataka directory',
-  (world: CooldownBeltComputerWorld, name: string) => {
-    writeAgentRecord(world.katakaDir!, name);
   },
 );
 
@@ -271,9 +251,8 @@ Then(
   'confidence is computed for agent {string}',
   (world: CooldownBeltComputerWorld, agentName: string) => {
     expect(world.lastError).toBeUndefined();
-    const calculator = world.agentConfidenceCalculatorSpy ?? world.katakaConfidenceCalculatorSpy;
-    expect(calculator).toBeDefined();
-    const calls = calculator!.compute.mock.calls as [string, string][];
+    expect(world.agentConfidenceCalculatorSpy).toBeDefined();
+    const calls = world.agentConfidenceCalculatorSpy!.compute.mock.calls as [string, string][];
     const match = calls.find(([, name]) => name === agentName);
     expect(match).toBeDefined();
   },
@@ -285,9 +264,6 @@ Then(
     expect(world.lastError).toBeUndefined();
     if (world.agentConfidenceCalculatorSpy) {
       expect(world.agentConfidenceCalculatorSpy.compute).not.toHaveBeenCalled();
-    }
-    if (world.katakaConfidenceCalculatorSpy) {
-      expect(world.katakaConfidenceCalculatorSpy.compute).not.toHaveBeenCalled();
     }
   },
 );

--- a/src/features/cycle-management/cooldown-belt-computer.test.ts
+++ b/src/features/cycle-management/cooldown-belt-computer.test.ts
@@ -164,60 +164,23 @@ describe('CooldownBeltComputer', () => {
       expect(computeSpy).toHaveBeenCalledWith(id2, 'Agent-B');
     });
 
-    it('prefers agentConfidenceCalculator over katakaConfidenceCalculator', () => {
-      const agentDir = join(tmpDir, 'agents-pref');
-      writeAgentRecord(agentDir, randomUUID(), 'X');
-
-      const canonicalSpy = vi.fn();
-      const legacySpy = vi.fn();
-      const computer = new CooldownBeltComputer(makeDeps({
-        agentDir,
-        agentConfidenceCalculator: { compute: canonicalSpy },
-        katakaConfidenceCalculator: { compute: legacySpy },
-      }));
-
-      computer.computeAgentConfidence();
-
-      expect(canonicalSpy).toHaveBeenCalled();
-      expect(legacySpy).not.toHaveBeenCalled();
-    });
-
-    it('prefers agentDir over katakaDir', () => {
-      const agentDir = join(tmpDir, 'agents-dir-pref');
-      const katakaDir = join(tmpDir, 'kataka-dir-pref');
-      writeAgentRecord(agentDir, randomUUID(), 'Canonical');
-      writeAgentRecord(katakaDir, randomUUID(), 'Legacy');
-
+    it('uses injected agentRegistry instead of constructing from agentDir', () => {
+      const id1 = randomUUID();
       const computeSpy = vi.fn();
+      const registryStub = { list: vi.fn(() => [{ id: id1, name: 'Injected' }]) };
+
       const computer = new CooldownBeltComputer(makeDeps({
-        agentDir,
-        katakaDir,
         agentConfidenceCalculator: { compute: computeSpy },
+        agentRegistry: registryStub,
       }));
 
       computer.computeAgentConfidence();
 
-      const names = computeSpy.mock.calls.map((c: [string, string]) => c[1]);
-      expect(names).toContain('Canonical');
-      expect(names).not.toContain('Legacy');
+      expect(registryStub.list).toHaveBeenCalledOnce();
+      expect(computeSpy).toHaveBeenCalledWith(id1, 'Injected');
     });
 
-    it('falls back to katakaConfidenceCalculator when canonical is absent', () => {
-      const katakaDir = join(tmpDir, 'kataka-fallback');
-      writeAgentRecord(katakaDir, randomUUID(), 'Fallback');
-
-      const legacySpy = vi.fn();
-      const computer = new CooldownBeltComputer(makeDeps({
-        katakaDir,
-        katakaConfidenceCalculator: { compute: legacySpy },
-      }));
-
-      computer.computeAgentConfidence();
-
-      expect(legacySpy).toHaveBeenCalledWith(expect.any(String), 'Fallback');
-    });
-
-    it('no-ops when calculator is provided but directory is missing', () => {
+    it('no-ops when calculator is provided but neither registry nor directory is available', () => {
       const computeSpy = vi.fn();
       const computer = new CooldownBeltComputer(makeDeps({
         agentConfidenceCalculator: { compute: computeSpy },

--- a/src/features/cycle-management/cooldown-belt-computer.ts
+++ b/src/features/cycle-management/cooldown-belt-computer.ts
@@ -12,11 +12,8 @@ export interface CooldownBeltDeps {
   beltCalculator?: Pick<BeltCalculator, 'computeAndStore'>;
   projectStateFile?: string;
   agentConfidenceCalculator?: Pick<KataAgentConfidenceCalculator, 'compute'>;
-  /** @deprecated Use `agentConfidenceCalculator` instead. Will be removed in v1. */
-  katakaConfidenceCalculator?: Pick<KataAgentConfidenceCalculator, 'compute'>;
   agentDir?: string;
-  /** @deprecated Use `agentDir` instead. Will be removed in v1. */
-  katakaDir?: string;
+  agentRegistry?: Pick<KataAgentRegistry, 'list'>;
 }
 
 /**
@@ -56,19 +53,17 @@ export class CooldownBeltComputer {
 
   /**
    * Recompute confidence profiles for all registered agents.
-   * Supports legacy kataka aliases (katakaConfidenceCalculator + katakaDir).
    *
    * Non-critical: computation errors are logged as warnings and swallowed
    * so that agent confidence failures do not abort cooldown.
    */
   computeAgentConfidence(): void {
-    const agentConfidenceCalculator = this.deps.agentConfidenceCalculator ?? this.deps.katakaConfidenceCalculator;
-    const agentDir = this.deps.agentDir ?? this.deps.katakaDir;
-    if (!agentConfidenceCalculator || !agentDir) return;
+    if (!this.deps.agentConfidenceCalculator) return;
+    if (!this.deps.agentRegistry && !this.deps.agentDir) return;
 
     let agents: { id: string; name: string }[];
     try {
-      const registry = new KataAgentRegistry(agentDir);
+      const registry = this.deps.agentRegistry ?? new KataAgentRegistry(this.deps.agentDir!);
       agents = registry.list();
     // Stryker disable next-line all: catch block is pure error-reporting — registry load failure
     } catch (err) {
@@ -78,7 +73,7 @@ export class CooldownBeltComputer {
 
     for (const agent of agents) {
       try {
-        agentConfidenceCalculator.compute(agent.id, agent.name);
+        this.deps.agentConfidenceCalculator.compute(agent.id, agent.name);
       // Stryker disable next-line all: catch block is pure error-reporting — per-agent failure
       } catch (err) {
         logger.warn(`Confidence computation failed for agent "${agent.name}": ${err instanceof Error ? err.message : String(err)}`);

--- a/src/features/cycle-management/cooldown-session-prepare.test.ts
+++ b/src/features/cycle-management/cooldown-session-prepare.test.ts
@@ -653,7 +653,7 @@ describe('CooldownSession.prepare() — observation wiring', () => {
   }
 
   function writeBridgeRun(runId: string, betId: string, cycleId: string): void {
-    const meta = { runId, betId, cycleId, cycleName: cycleId, stages: ['research', 'build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'complete' };
+    const meta = { runId, betId, betName: 'test bet', cycleId, cycleName: cycleId, stages: ['research', 'build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'complete' };
     writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify(meta, null, 2) + '\n');
   }
 

--- a/src/features/cycle-management/cooldown-session.test.ts
+++ b/src/features/cycle-management/cooldown-session.test.ts
@@ -553,32 +553,6 @@ describe('CooldownSession', () => {
       expect(agentConfidenceCalculator.compute).toHaveBeenCalledWith(betaId, 'Beta');
     });
 
-    it('supports kataka compatibility aliases during complete()', async () => {
-      const katakaDir = join(baseDir, 'agents-compat');
-      const agentId = randomUUID();
-      writeAgentRecord(katakaDir, agentId, 'Compat Agent');
-
-      const cycle = cycleManager.create({ tokenBudget: 50000 }, 'Compat Agent Cycle');
-      const synthesisDir = join(baseDir, 'synthesis-agent-compat');
-      mkdirSync(synthesisDir, { recursive: true });
-
-      const katakaConfidenceCalculator = { compute: vi.fn() };
-      const sessionWithCompat = new CooldownSession({
-        cycleManager,
-        knowledgeStore,
-        persistence: JsonStore,
-        pipelineDir,
-        historyDir,
-        synthesisDir,
-        katakaDir,
-        katakaConfidenceCalculator,
-      });
-
-      await sessionWithCompat.prepare(cycle.id);
-      await sessionWithCompat.complete(cycle.id);
-
-      expect(katakaConfidenceCalculator.compute).toHaveBeenCalledWith(agentId, 'Compat Agent');
-    });
   });
 
   describe('belt advancement integration', () => {
@@ -1774,7 +1748,7 @@ describe('CooldownSession', () => {
       }));
 
       // Write bridge-run file as 'complete' — should take precedence over stale run.json
-      writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify({ runId, betId: bet.id, cycleId: cycle.id, cycleName: 'Test', stages: ['build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'complete' }));
+      writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify({ runId, betId: bet.id, betName: 'Complete bridge bet', cycleId: cycle.id, cycleName: 'Test', stages: ['build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'complete' }));
 
       const sessionWithBridge = new CooldownSession({
         cycleManager, knowledgeStore, persistence: JsonStore, pipelineDir, historyDir, bridgeRunsDir, runsDir,
@@ -1795,7 +1769,7 @@ describe('CooldownSession', () => {
       cycleManager.setRunId(cycle.id, bet.id, runId);
 
       
-      writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify({ runId, betId: bet.id, cycleId: cycle.id, cycleName: 'Test', stages: ['build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'in-progress' }));
+      writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify({ runId, betId: bet.id, betName: 'In-progress bridge bet', cycleId: cycle.id, cycleName: 'Test', stages: ['build'], isolation: 'shared', startedAt: new Date().toISOString(), status: 'in-progress' }));
 
       const sessionWithBridge = new CooldownSession({
         cycleManager, knowledgeStore, persistence: JsonStore, pipelineDir, historyDir, bridgeRunsDir,

--- a/src/features/cycle-management/cooldown-session.ts
+++ b/src/features/cycle-management/cooldown-session.ts
@@ -124,17 +124,9 @@ export interface CooldownSessionDeps {
    */
   agentConfidenceCalculator?: Pick<KataAgentConfidenceCalculator, 'compute'>;
   /**
-   * @deprecated Use `agentConfidenceCalculator` instead. Will be removed in v1.
-   */
-  katakaConfidenceCalculator?: Pick<KataAgentConfidenceCalculator, 'compute'>;
-  /**
    * Optional path to the agent registry directory. Required when agentConfidenceCalculator is provided.
    */
   agentDir?: string;
-  /**
-   * @deprecated Use `agentDir` instead. Will be removed in v1.
-   */
-  katakaDir?: string;
   /**
    * Optional injected NextKeikoProposalGenerator for testability.
    * When omitted and runsDir is set, a NextKeikoProposalGenerator is constructed automatically.
@@ -196,9 +188,7 @@ export class CooldownSession {
       beltCalculator: deps.beltCalculator,
       projectStateFile: deps.projectStateFile,
       agentConfidenceCalculator: deps.agentConfidenceCalculator,
-      katakaConfidenceCalculator: deps.katakaConfidenceCalculator,
       agentDir: deps.agentDir,
-      katakaDir: deps.katakaDir,
     });
     this.diaryWriter = new CooldownDiaryWriter({
       dojoDir: deps.dojoDir,

--- a/src/features/cycle-management/cooldown-session.unit.test.ts
+++ b/src/features/cycle-management/cooldown-session.unit.test.ts
@@ -98,6 +98,12 @@ function writeBridgeRun(
 ): void {
   writeFileSync(join(bridgeRunsDir, `${runId}.json`), JSON.stringify({
     runId,
+    betName: 'test bet',
+    cycleName: 'Test Cycle',
+    stages: ['build'],
+    isolation: 'shared',
+    startedAt: '2026-03-22T10:00:00.000Z',
+    status: 'complete',
     ...data,
   }));
 }


### PR DESCRIPTION
## Summary

Wave 3B cleanup fixes for the CooldownSession decomposition (#375):

- **Fix 1**: Remove deprecated `katakaConfidenceCalculator` and `katakaDir` from `CooldownBeltDeps` and `CooldownSessionDeps` — no public API consumers exist
- **Fix 2**: Add injectable `agentRegistry` to `CooldownBeltDeps` — eliminates concrete infra dependency (`new KataAgentRegistry`) inside a features-layer class
- **Fix 3**: Wire `BridgeRunSyncer` to `bridge-run-store` adapter — replaces raw `readFileSync` + `JSON.parse` with Zod-validated `readBridgeRunMeta()` and `listBridgeRunsForCycle()`, eliminating ~26 lines of duplicate fs code

Closes #395

## Impact

- 11 files changed, +60 / -165 lines (net -105)
- BridgeRunSyncer: 195 → 169 lines
- CooldownBeltComputer: 89 → 82 lines
- All quality gates pass: verify, acceptance (112), e2e

## Test plan

- [x] `npm run verify` passes (lint + typecheck + unit + integration + e2e + build)
- [x] `npm run test:acceptance` passes (112 scenarios)
- [x] BridgeRunSyncer tests updated for Zod-validated bridge-run metadata
- [x] Kataka legacy test scenarios removed from feature files and step definitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bridge-run metadata schema compliance by ensuring deterministic base objects are always written.
  * Improved handling of incomplete or malformed metadata files with stricter validation.

* **Refactor**
  * Removed legacy "kataka" compatibility configuration in favor of standardized agent registry approach.
  * Simplified agent confidence computation by consolidating to a single registry interface.
  * Refactored internal metadata discovery to use persistence-layer helpers for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->